### PR TITLE
Clarification of pattern (un)subscription

### DIFF
--- a/topics/pubsub.md
+++ b/topics/pubsub.md
@@ -111,6 +111,11 @@ Will receive all the messages sent to the channel `news.art.figurative`,
 `news.music.jazz`, etc.  All the glob-style patterns are valid, so
 multiple wildcards are supported.
 
+    PUNSUBSCRIBE news.*
+
+Will then unsubscribe the client from that pattern.  No other subscriptions
+will be affected by this call.
+
 Messages received as a result of pattern matching are sent in a
 different format:
 


### PR DESCRIPTION
After my confusion about this that led to my invalid bug filing (http://code.google.com/p/redis/issues/detail?id=529), I wanted to clarify this in the docs to prevent any other wayward souls from making the same mistake.  What I've added is simple and very literal, but it was exactly what I spent the time searching the doc for.

It could be that the clarification should be in the punsubscribe command page, but I think it makes more sense here.  Everything in that page makes sense as long as one has already realized that subscribing to a pattern and all the channels that could ever make up that pattern are not the same (a leap I had not made until antirez clarified it for me).  In other words, it's already there, but sometimes being very explicit is a good thing.  The topic guide seems like a better place to throw the additional clarification.

Thanks.  Apologies for sending pull request larger than diff.
