### PR TITLE
added a site to 'whos using' list

### DIFF
--- a/topics/whos-using-redis.md
+++ b/topics/whos-using-redis.md
@@ -81,6 +81,7 @@ And many others:
 * [localshow.tv](http://localshow.tv/)
 * [PennyAce](http://pennyace.com/)
 * [Nasza Klasa](http://nk.pl/)
+* [GraphBug](http://graphbug.com/)
 
 This list is incomplete. If you're using Redis and would like to be
 listed, [send a pull request](https://github.com/antirez/redis-doc).


### PR DESCRIPTION
I added graphbug to the who's using list.  graphbug can be used to search, graph, and combine public data from many sources.  All of the datasets and the metadata are stored in redis.
