### PR TITLE
Update docs for EXPIRE/EXPIREAT

### DIFF
--- a/commands/expire.md
+++ b/commands/expire.md
@@ -7,6 +7,9 @@ Set a timeout on `key`. After the timeout has expired, the key will
 automatically be deleted. A key with an associated timeout is said to be
 _volatile_ in Redis terminology.
 
+If `key` is updated before the timeout has expired, then the timeout is removed
+as if the `PERSIST` command was invoked on `key`.
+
 For Redis versions **< 2.1.3**, existing timeouts cannot be overwritten. So, if
 `key` already has an associated timeout, it will do nothing and return `0`.
 Since Redis **2.1.3**, you can update the timeout of a key. It is also possible
@@ -28,4 +31,5 @@ for more information.
     SET mykey "Hello"
     EXPIRE mykey 10
     TTL mykey
-
+    SET mykey "Hello World"
+    TTL mykey

--- a/commands/expireat.md
+++ b/commands/expireat.md
@@ -11,6 +11,10 @@ _volatile_ in Redis terminology.
 specifying the number of seconds representing the TTL (time to live), it takes
 an absolute [UNIX timestamp][2] (seconds since January 1, 1970).
 
+As in the case of `EXPIRE` command, if `key` is updated before the timeout has
+expired, then the timeout is removed as if the `PERSIST` command was invoked on
+`key`.
+
 [2]: http://en.wikipedia.org/wiki/Unix_time
 
 ## Background


### PR DESCRIPTION
Extend `EXPIRE`/`EXPIREAT` documentation to indicate the timeout will be removed if the key is updated before timing out.
