### PR TITLE
updated redis-clojure

### DIFF
--- a/clients.json
+++ b/clients.json
@@ -20,9 +20,9 @@
   {
     "name": "redis-clojure",
     "language": "Clojure",
-    "repository": "https://github.com/ragnard/redis-clojure",
+    "repository": "https://github.com/tavisrudd/redis-clojure",
     "description": "",
-    "authors": ["ragge"]
+    "authors": ["tavisrudd"]
   },
 
   {


### PR DESCRIPTION
The version currently listed only works with clojure 1.1 and is missing quite a few commands.  This updated version works with 1.2 and 1.3, has connection pooling and other goodies.
