### PR TITLE
ZSET members and scores.

### DIFF
--- a/commands/zadd.md
+++ b/commands/zadd.md
@@ -27,6 +27,7 @@ sets](/topics/data-types#sorted-sets).
 
     @cli
     ZADD myzset 1 "one"
+    ZADD myzset 1 "uno"
     ZADD myzset 2 "two"
     ZADD myzset 3 "two"
     ZRANGE myzset 0 -1 WITHSCORES

--- a/topics/data-types.md
+++ b/topics/data-types.md
@@ -108,7 +108,8 @@ Sorted sets
 Redis Sorted Sets are, similarly to Redis Sets, non repeating collections of
 Strings. The difference is that every member of a Sorted Set is associated
 with score, that is used in order to take the sorted set ordered, from the
-smallest to the greatest score.
+smallest to the greatest score.  While members are unique, scores may be
+repeated.
 
 With sorted sets you can add, remove, or update elements in a very fast way
 (in a time proportional to the logarithm of the number of elements). Since


### PR DESCRIPTION
For a long time, I was confused about the uniqueness constraint in ZSETs and the behavior of ZADD.  I thought that the _score_ must be unique, not the _member_, which is backwards.

I looked over the documentation, and while nothing contradicts the truth, there was no simple statement that scores can be repeated.

I added a sentence to the datatypes explanation and an example to the ZADD command that demonstrates this behavior, and verified that it works without requiring modification to redis-io.
