### PR TITLE
Quick note about the inaccuracy of EXPIRE

### DIFF
--- a/commands/expire.md
+++ b/commands/expire.md
@@ -16,7 +16,7 @@ Since Redis **2.1.3**, you can update the timeout of a key. It is also possible
 to remove the timeout using the `PERSIST` command. See the page on [key expiry][1]
 for more information.
 
-Note that expire might is not pin-point accurate it could be anywhere
+Note that expire might not be pin-point accurate it; could be anywhere
 between zero to one seconds out.
 
 [1]: /topics/expire


### PR DESCRIPTION
There was a brief discussion about the EXPIRE command not being nail-on-the-head accurate:

https://groups.google.com/forum/#!topic/redis-db/b1zDylwCTno

And I've raised a bug about it:

https://github.com/antirez/redis/issues/169

Obviously I would love for the powers that be to decide it's a bug that needs fixing but for now please accept this pull request so that people know this possible pitfall.
