### PR TITLE
LRANGE documentation typo: `end` vs `stop`

### DIFF
--- a/commands/lrange.md
+++ b/commands/lrange.md
@@ -4,7 +4,7 @@ O(S+N) where S is the `start` offset and N is the number of elements in the
 specified range.
 
 Returns the specified elements of the list stored at `key`.  The offsets
-`start` and `end` are zero-based indexes, with `0` being the first element of
+`start` and `stop` are zero-based indexes, with `0` being the first element of
 the list (the head of the list), `1` being the next element and so on.
 
 These offsets can also be negative numbers indicating offsets starting at the
@@ -22,7 +22,7 @@ Python's `range()` function).
 ## Out-of-range indexes
 
 Out of range indexes will not produce an error. If `start` is larger than the
-end of the list, or `start > end`, an empty list is returned.  If `end` is
+end of the list, an empty list is returned.  If `stop` is
 larger than the actual end of the list, Redis will treat it like the last
 element of the list.
 


### PR DESCRIPTION
The command is documented as "LRANGE key start stop". That said, the documentation contained references to `end` parameter when it should be `stop`.

Also I removed a redundant part.
