### PR TITLE
Add Haskell client 'Hedis' to clients.json

### DIFF
--- a/clients.json
+++ b/clients.json
@@ -83,6 +83,15 @@
   },
 
   {
+    "name": "hedis",
+    "language": "Haskell",
+    "url": "http://hackage.haskell.org/package/hedis",
+    "repository": "https://github.com/informatikr/hedis",
+    "description": "Supports the complete command set. Commands are automatically pipelined for high performance.",
+    "authors": []
+  },
+
+  {
     "name": "redis",
     "language": "Haskell",
     "url": "http://hackage.haskell.org/package/redis",


### PR DESCRIPTION
Hello,

please accept this commit. It adds my Haskell client library [Hedis](http://hackage.haskell.org/package/hedis) to `clients.json`.

The Hedis library
- supports the complete command set,
- does [automatic optimal pipelining](http://informatikr.com/2012/redis-pipelining.html),
- connects via TCP or Unix domain sockets.

There is at least one independent recommendation for Hedis [on the Redis mailing list](http://groups.google.com/group/redis-db/browse_thread/thread/b894a9ed97104dec?pli=1).
