### PR TITLE
Add Credis to list of PHP drivers.

### DIFF
--- a/clients.json
+++ b/clients.json
@@ -248,6 +248,14 @@
   },
 
   {
+    "name": "Credis",
+    "language": "PHP",
+    "repository": "https://github.com/colinmollenhour/credis",
+    "description": "Lightweight, standalone, unit-tested fork of Redisent which wraps phpredis for best performance if available.",
+    "authors": ["colinmollenhour"]
+  },
+
+  {
     "name": "redis-py",
     "language": "Python",
     "repository": "https://github.com/andymccurdy/redis-py",


### PR DESCRIPTION
I forked Redisent and nearly rewrote the basic client resulting in many notable improvements including:
- Uses phpredis (compiled extension) if installed for improved performance, but works standalone if phpredis is not installed
- PEAR-style autoload-compatible class naming
- Unit-tested both standalone and wrapper mode (PHPUnit)
- Supports connection over Unix sockets, specified timeout
- Adds full support for pipeline and transaction modes
- Reduced memory usage for large commands
- Accepts arrays as arguments (e.g. SADD, DEL, HMSET, etc..)
- IDE-friendly var-docs added for magic methods
- Probably more..

I've been using it in production for quite some time as it is the library used by the Zend_Cache backend I wrote which supports tagging using redis sets and hashes.
