### PR TITLE
latency topic grep process_id typo fixed

### DIFF
--- a/topics/latency.md
+++ b/topics/latency.md
@@ -184,7 +184,7 @@ this is the case.
 The first thing to do is to checking the amount of Redis memory that is swapped
 on disk. In order to do so you need to obtain the Redis instance pid:
 
-    $ redis-cli info | grep redis-cli info | grep process_id
+    $ redis-cli info | grep process_id
     process_id:5454
 
 Now enter the /proc file system directory for this process:


### PR DESCRIPTION
I noticed this: redis-cli info | grep redis-cli info | grep process_id

contained a typo so I changed it to: redis-cli info | grep process_id

~ > redis-cli info | grep redis-cli info | grep process_id
grep: info: No such file or directory
~ > 
~ > 
~ > redis-cli info | grep process_id
process_id:248
~ > 
