### PR TITLE
fix BITOP command 

### DIFF
--- a/commands.json
+++ b/commands.json
@@ -63,12 +63,12 @@
     "complexity": "O(N)",
     "arguments": [
       {
-        "name": "destkey",
-        "type": "key"
-      },
-      {
         "name": "operation",
         "type": "string"
+      },
+      {
+        "name": "destkey",
+        "type": "key"
       },
       {
         "name": "key",
@@ -77,7 +77,7 @@
       }
     ],
     "since": "2.6.0",
-    "group": "list"
+    "group": "string"
   },
   "BLPOP": {
     "summary": "Remove and get the first element in a list, or block until one is available",


### PR DESCRIPTION
The format of BITOP command should be "BITOP operation destkey key [key ...]", not "BITOP destkey operation key [key ...]" .

And it should be a "string" command, right?
