### PR TITLE
Fix bug in Ruby EVAL example.

### DIFF
--- a/commands/eval.md
+++ b/commands/eval.md
@@ -361,7 +361,7 @@ RandomPushScript = <<EOF
 EOF
 
 r.del(:mylist)
-puts r.eval(RandomPushScript,1,:mylist,10)
+puts r.eval(RandomPushScript,[:mylist],[10,rand(2**32)])
 ```
 
 Every time this script executed the resulting list will have exactly the


### PR DESCRIPTION
I had trouble getting the ruby example working, and if I'm reading it right, ruby-rb appears to not accept the second "number of args" arg.

https://github.com/redis/redis-rb/blob/master/lib/redis.rb#L2112

It also wants keys and args as either arrays or keyed. Once I made the following changes, the example works as expected for me.
