### PR TITLE
Handle multibyte values in sample protocol generator

### DIFF
--- a/topics/mass-insert.md
+++ b/topics/mass-insert.md
@@ -99,7 +99,7 @@ The following Ruby function generates valid protocol:
         proto = ""
         proto << "*"+cmd.length.to_s+"\r\n"
         cmd.each{|arg|
-            proto << "$"+arg.length.to_s+"\r\n"
+            proto << "$"+arg.to_s.bytesize.to_s+"\r\n"
             proto << arg.to_s+"\r\n"
         }
         proto


### PR DESCRIPTION
- Length needs to be number of bytes not number of characters
- Fixes 'RR Protocol error: expected '$', got ' error
- Ruby 1.8.7+ compatible
