### PR TITLE
Fixed typo in pub/sub messages

### DIFF
--- a/topics/sentinel.md
+++ b/topics/sentinel.md
@@ -237,9 +237,9 @@ and is only specified if the instance is not a master itself.
 * **+slave** `<instance details>` -- A new slave was detected and attached.
 * **+failover-state-reconf-slaves** `<instance details>` -- Failover state changed to `reconf-slaves` state.
 * **+failover-detected** `<instance details>` -- A failover started by another Sentinel or any other external entity was detected (An attached slave turned into a master).
-* **+salve-reconf-sent** `<instance details>` -- The leader sentinel sent the `SLAVEOF` command to this instance in order to reconfigure it for the new slave.
-* **+salve-reconf-inprog** `<instance details>` -- The slave being reconfigured showed to be a slave of the new master ip:port pair, but the synchronization process is not yet complete.
-* **+salve-reconf-done** `<instance details>` -- The slave is now synchronized with the new master.
+* **+slave-reconf-sent** `<instance details>` -- The leader sentinel sent the `SLAVEOF` command to this instance in order to reconfigure it for the new slave.
+* **+slave-reconf-inprog** `<instance details>` -- The slave being reconfigured showed to be a slave of the new master ip:port pair, but the synchronization process is not yet complete.
+* **+slave-reconf-done** `<instance details>` -- The slave is now synchronized with the new master.
 * **-dup-sentinel** `<instance details>` -- One or more sentinels for the specified master were removed as duplicated (this happens for instance when a Sentinel instance is restarted).
 * **+sentinel** `<instance details>` -- A new sentinel for this master was detected and attached.
 * **+sdown** `<instance details>` -- The specified instance is now in Subjectively Down state.
@@ -534,7 +534,7 @@ At this point you should see something like the following in every Sentinel you 
     [4747] 23 Jul 14:49:19.645 * +sentinel sentinel 127.0.0.1:26379 127.0.0.1 26379 @ mymaster 127.0.0.1 6379
     [4747] 23 Jul 14:49:21.659 * +sentinel sentinel 127.0.0.1:26381 127.0.0.1 26381 @ mymaster 127.0.0.1 6379
 
-    redis-cli -p 26379 sentinel masters                                        
+    redis-cli -p 26379 sentinel masters
     1)  1) "name"
         2) "mymaster"
         3) "ip"


### PR DESCRIPTION
Messages `+salve-reconf-sent`, `+salve-reconf-inprog` and `+salve-reconf-done` changed to `+slave-reconf-sent`, `+slave-reconf-inprog` and `+slave-reconf-done`, respectively.
