### PR TITLE
Add explanations about memory related kernel settings

### DIFF
--- a/topics/admin.md
+++ b/topics/admin.md
@@ -8,7 +8,7 @@ Redis setup hints
 -----------------
 
 + We suggest deploying Redis using the **Linux operating system**. Redis is also tested heavily on osx, and tested from time to time on FreeBSD and OpenBSD systems. However Linux is where we do all the major stress testing, and where most production deployments are working.
-+ Make sure to set the Linux kernel **overcommit memory setting to 1**. Add `vm.overcommit_memory = 1` to `/etc/sysctl.conf` and then reboot or run the command `sysctl vm.overcommit_memory=1` for this to take effect immediately.
++ Make sure to set the Linux kernel **overcommit memory setting to 1**. Add `vm.overcommit_memory = 1` to `/etc/sysctl.conf` and then reboot or run the command `sysctl vm.overcommit_memory=1` for this to take effect immediately. For more info see [our FAQ](/topics/faq#BackgroundSaving)
 + Make sure to **setup some swap** in your system (we suggest as much as swap as memory). If Linux does not have swap and your Redis instance accidentally consumes too much memory, either Redis will crash for out of memory or the Linux kernel OOM killer will kill the Redis process.
 + If you are using Redis in a very write-heavy application, while saving an RDB file on disk or rewriting the AOF log **Redis may use up to 2 times the memory normally used**. The additional memory used is proportional to the number of memory pages modified by writes during the saving process, so it is often proportional to the number of keys (or aggregate types items) touched during this time. Make sure to size your memory accordingly.
 + Even if you have persistence disabled, Redis will need to perform RDB saves if you use replication.

--- a/topics/faq.md
+++ b/topics/faq.md
@@ -68,7 +68,7 @@ with an error to write commands (but will continue to accept read-only
 commands), or you can configure it to evict keys when the max memory limit
 is reached in the case you are using Redis for caching.
 
-## Background saving is failing with a fork() error under Linux even if I've a lot of free RAM!
+## Background saving is failing with a fork() error under Linux even if I've a lot of free RAM! ## {#BackgroundSaving}
 
 Short answer: `echo 1 > /proc/sys/vm/overcommit_memory` :)
 
@@ -90,6 +90,9 @@ memory it will fail.
 
 Setting `overcommit_memory` to 1 says Linux to relax and perform the fork in a
 more optimistic allocation fashion, and this is indeed what you want for Redis.
+
+Please note that it is naïve to change `overcommit_memory` without verifying a
+sane setting for `overcommit_ratio`.
 
 A good source to understand how Linux Virtual Memory work and other
 alternatives for `overcommit_memory` and `overcommit_ratio` is this classic


### PR DESCRIPTION
I hope the 
## foo ## {#Foo}

Style of creating Markdown anchors works with this version of Markdown.
