### PR TITLE
Make Hedis the recommended Haskell client

### DIFF
--- a/clients.json
+++ b/clients.json
@@ -109,6 +109,7 @@
     "repository": "https://github.com/informatikr/hedis",
     "description": "Supports the complete command set. Commands are automatically pipelined for high performance.",
     "authors": [],
+    "recommended": true,
     "active": true
   },
 


### PR DESCRIPTION
Hi,

(disclaimer: I am the author of Hedis)

please accept my patch to make Hedis the recommended Haskell client for the following reasons:
- Hedis is the only maintained client for Haskell.  On Hackage, the Haskell package database, there are currently two other Redis clients ("redis" and "redis-hs") but both are no longer maintained. In fact the author of the "redis" client now [recommends Hedis](http://hackage.haskell.org/package/redis).
- Hedis has integration packages with the two major Haskell web frameworks, [Snap](http://hackage.haskell.org/package/snaplet-redis) and [Yesod](http://hackage.haskell.org/package/wai-middleware-cache-redis).
- Hedis supports the [entire Redis 2.6 API](http://hackage.haskell.org/packages/archive/hedis/0.6.1/doc/html/Database-Redis.html) (except MONITOR, SYNC, SHUTDOWN, DEBUG SEGFAULT).
- Hedis is quite fast.

Thanks for all your work on Redis!
