### PR TITLE
Add scala-redis-client to clients.json

### DIFF
--- a/clients.json
+++ b/clients.json
@@ -350,6 +350,15 @@
   },
 
   {
+    "name": "scala-redis-client",
+    "language": "Scala",
+    "repository": "https://github.com/top10/scala-redis-client",
+    "description": "An idiomatic Scala client that keeps Jedis / Java hidden. Used in production at http://top10.com.",
+    "authors": ["thesmith", "heychinaski"],
+    "active": true
+  },
+
+  {
     "name": "Tcl Client",
     "language": "Tcl",
     "repository": "https://github.com/antirez/redis/blob/unstable/tests/support/redis.tcl",


### PR DESCRIPTION
There's a number of clients listed for Scala but, humbly, none of them were fit-for-purpose when we needed them, so we ended up wrapping Java's Jedis. We've been using it for a while now so I thought it was time we opened it up and pointed people at it.
