### PR TITLE
commands.json: ZADD specification logic fix

### DIFF
--- a/commands.json
+++ b/commands.json
@@ -1821,22 +1821,9 @@
         "type": "key"
       },
       {
-        "name": "score",
-        "type": "double"
-      },
-      {
-        "name": "member",
-        "type": "string"
-      },
-      {
-        "name": "score",
-        "type": "double",
-        "optional": true
-      },
-      {
-        "name": "member",
-        "type": "string",
-        "optional": true
+        "name": ["score", "member"],
+        "type": ["double", "string"],
+        "multiple": true
       }
     ],
     "since": "1.2.0",


### PR DESCRIPTION
ZADD parameters "score" and "member" are described wrong in commands.json file. 

It has the 4-th ("score") and 5-th ("member") parameters defined as optional instead of to define a pair of the ["score", "member"] parameters with "multiple": true option turned on.

It looks currently like there could be specified only 1 or 2 of score-member pairs (not 3 or more pairs), and even like the second "member" element could be omited.

Though it looks equal in the resulting HTML documentation, it would be nice to have ZADD defined like other similar commands with "multiple": true.
