### PR TITLE
INFO now supports an optional section parameter

### DIFF
--- a/commands.json
+++ b/commands.json
@@ -723,6 +723,13 @@
   },
   "INFO": {
     "summary": "Get information and statistics about the server",
+    "arguments": [
+      {
+        "name": "section",
+        "type": "string",
+        "optional": true
+      }
+    ],
     "since": "1.0.0",
     "group": "server"
   },


### PR DESCRIPTION
A user of my client pointed out that my generated clients do not
support the optional INFO parameter. This is because it was missing
from the machine API description.
