### PR TITLE
Adding gosexy/redis (Go bindings for hiredis) to the list of clients.

### DIFF
--- a/clients.json
+++ b/clients.json
@@ -127,6 +127,15 @@
     "authors": ["simonz05"],
     "active": true
   },
+  
+  {
+    "name": "gosexy/redis",
+    "language": "Go",
+    "repository": "https://github.com/gosexy/redis",
+    "description": "Go bindings for the official C redis client (hiredis), supports the whole command set of redis 2.6.10 and subscriptions with go channels.",
+    "authors": ["xiam"],
+    "active": true
+  },
 
   {
     "name": "hedis",


### PR DESCRIPTION
Hello antirez,

Just a kind request to include my Go bindings for hiredis into the list of clients. This package uses the official C client as base and extends it with Go idioms, it also implements subscriptions using goroutines and channels.

Please note that I use a copy of the official hiredis repo (_hiredis directory) instead of a submodule and that's because the go installation command "go get" does not support cloning submodules (yet), once the tool supports submodule cloning or until I find a better alternative I'll discard the fork.

Best,

José Carlos.
