### PR TITLE
Add ruby em-hiredis client

### DIFF
--- a/clients.json
+++ b/clients.json
@@ -488,6 +488,14 @@
   },
 
   {
+    "name": "em-hiredis",
+    "language": "Ruby",
+    "repository": "https://github.com/mloughran/em-hiredis",
+    "description": "An EventMachine Redis client (uses hiredis).",
+    "authors": ["mloughran"]
+  },
+
+  {
     "name": "em-redis",
     "language": "Ruby",
     "repository": "https://github.com/madsimian/em-redis",


### PR DESCRIPTION
I'd also recommend removing the em-redis listing since that gem is no longer maintained and it's presence will just cause confusion - of course I may be slightly biased :)
