### PR TITLE
include mod-redis-io client for the Vert.x framework

### DIFF
--- a/clients.json
+++ b/clients.json
@@ -213,6 +213,14 @@
   },
 
   {
+    "name": "mod-redis-io",
+    "language": "Java",
+    "repository": "https://github.com/pmlopes/mod-redis-io",
+    "description": "Asynchronous redis.io bus module for Vert.x",
+    "authors": ["pmlopes"],
+  },
+
+{
     "name": "redis-lua",
     "language": "Lua",
     "repository": "https://github.com/nrk/redis-lua",


### PR DESCRIPTION
This module is currently supporting Vert.x 1.3 and the development branch supports the upcoming 2.0 release.
