### PR TITLE
Add finagle-redis to scala clients

### DIFF
--- a/clients.json
+++ b/clients.json
@@ -669,5 +669,13 @@
     "repository": "https://github.com/ctstone/csredis",
     "description": "Async (and sync) client for Redis and Sentinel",
     "authors": ["ctnstone"]
+  },
+
+  {
+    "name": "finagle-redis",
+    "language": "Scala",
+    "repository": "https://github.com/twitter/finagle",
+    "description": "Redis client based on Finagle",
+    "authors": [""]
   }
 ]


### PR DESCRIPTION
We have a Redis client based on Finagle at Twitter, I would love to add it to the official clients list.