### PR TITLE
guile-redis client

### DIFF
--- a/clients.json
+++ b/clients.json
@@ -669,5 +669,13 @@
     "repository": "https://github.com/ctstone/csredis",
     "description": "Async (and sync) client for Redis and Sentinel",
     "authors": ["ctnstone"]
+  },
+
+  {
+    "name": "guile-redis",
+    "language": "Scheme",
+    "repository": "https://github.com/aconchillo/guile-redis",
+    "description": "A simple redis client for Guile",
+    "authors": ["aconchillo"]
   }
 ]


### PR DESCRIPTION
A redis client for Guile (Scheme). It supports most of the commands up to redis 2.6.14.
