### PR TITLE
Document COPY and REPLACE option for migrate.

### DIFF
--- a/commands.json
+++ b/commands.json
@@ -964,6 +964,18 @@
       {
         "name": "timeout",
         "type": "integer"
+      },
+      {
+        "name": "copy",
+        "type": "enum",
+        "enum": ["COPY"],
+        "optional": true
+      },
+      {
+        "name": "replace",
+        "type": "enum",
+        "enum": ["REPLACE"],
+        "optional": true
       }
     ],
     "since": "2.6.0",

--- a/commands/migrate.md
+++ b/commands/migrate.md
@@ -37,6 +37,11 @@ same name was also _already_ present on the target instance).
 
 On success OK is returned.
 
+## Options
+
+* `COPY` -- Do not remove the key from the local instance.
+* `REPLACE` -- Replace existing key on the remote instance.
+
 @return
 
 @status-reply: The command returns OK on success.


### PR DESCRIPTION
`MIGRATE` was missing both these options in the documentation. I hope I got the json right.
