### PR TITLE
Updated clients.json to include hierdis

### DIFF
--- a/clients.json
+++ b/clients.json
@@ -48,7 +48,7 @@
   {
     "name": "hierdis",
     "language": "Erlang",
-    "repository": "https://github.com/nathanaschbacher/hierdis",
+    "repository": "https://github.com/basho-labs/hierdis",
     "description": "High-performance Erlang NIF-based client for the Redis key-value store.",
     "authors": ["nathanaschbacher"],
     "active": true

--- a/clients.json
+++ b/clients.json
@@ -46,6 +46,15 @@
   },
 
   {
+    "name": "hierdis",
+    "language": "Erlang",
+    "repository": "https://github.com/nathanaschbacher/hierdis",
+    "description": "High-performance Erlang NIF-based client for the Redis key-value store.",
+    "authors": ["nathanaschbacher"],
+    "active": true
+  },
+
+  {
     "name": "Erldis",
     "language": "Erlang",
     "repository": "https://github.com/japerk/erldis",


### PR DESCRIPTION
hierdis is an Erlang client for Redis built as a NIF that wraps the hiredis C-library.