### PR TITLE
Haxe was renamed

### DIFF
--- a/clients.json
+++ b/clients.json
@@ -489,7 +489,7 @@
 
   {
     "name": "hxneko-redis",
-    "language": "haXe",
+    "language": "Haxe",
     "url": "http://code.google.com/p/hxneko-redis",
     "repository": "http://code.google.com/p/hxneko-redis/source/browse",
     "description": "",


### PR DESCRIPTION
Haxe was renamed. From "haXe" to "Haxe".

See [official website](http://haxe.org/).