### PR TITLE
Fix vm.overcommit faq

### DIFF
--- a/topics/faq.md
+++ b/topics/faq.md
@@ -252,7 +252,7 @@ more optimistic allocation fashion, and this is indeed what you want for Redis.
 A good source to understand how Linux Virtual Memory work and other
 alternatives for `overcommit_memory` and `overcommit_ratio` is this classic
 from Red Hat Magazine, ["Understanding Virtual Memory"][redhatvm].
-Beware, this article had 1 and 2 configuration value for `overcommit_memory`
+Beware, this article had `1` and `2` configuration values for `overcommit_memory`
 reversed: refer to the [proc(5)][proc5] man page for the right meaning of the
 available values.
 

--- a/topics/faq.md
+++ b/topics/faq.md
@@ -252,8 +252,12 @@ more optimistic allocation fashion, and this is indeed what you want for Redis.
 A good source to understand how Linux Virtual Memory work and other
 alternatives for `overcommit_memory` and `overcommit_ratio` is this classic
 from Red Hat Magazine, ["Understanding Virtual Memory"][redhatvm].
+Beware, this article had 1 and 2 configurtation value for `overcommit_memory`
+reversed: reffer to the ["proc(5)"][proc5] man page for the right meaning of the
+available values.
 
 [redhatvm]: http://www.redhat.com/magazine/001nov04/features/vm/
+[proc5]: http://man7.org/linux/man-pages/man5/proc.5.html
 
 ## Are Redis on disk snapshots atomic?
 

--- a/topics/faq.md
+++ b/topics/faq.md
@@ -252,8 +252,8 @@ more optimistic allocation fashion, and this is indeed what you want for Redis.
 A good source to understand how Linux Virtual Memory work and other
 alternatives for `overcommit_memory` and `overcommit_ratio` is this classic
 from Red Hat Magazine, ["Understanding Virtual Memory"][redhatvm].
-Beware, this article had 1 and 2 configurtation value for `overcommit_memory`
-reversed: reffer to the [proc(5)][proc5] man page for the right meaning of the
+Beware, this article had 1 and 2 configuration value for `overcommit_memory`
+reversed: refer to the [proc(5)][proc5] man page for the right meaning of the
 available values.
 
 [redhatvm]: http://www.redhat.com/magazine/001nov04/features/vm/

--- a/topics/faq.md
+++ b/topics/faq.md
@@ -253,7 +253,7 @@ A good source to understand how Linux Virtual Memory work and other
 alternatives for `overcommit_memory` and `overcommit_ratio` is this classic
 from Red Hat Magazine, ["Understanding Virtual Memory"][redhatvm].
 Beware, this article had 1 and 2 configurtation value for `overcommit_memory`
-reversed: reffer to the ["proc(5)"][proc5] man page for the right meaning of the
+reversed: reffer to the [proc(5)][proc5] man page for the right meaning of the
 available values.
 
 [redhatvm]: http://www.redhat.com/magazine/001nov04/features/vm/


### PR DESCRIPTION
The "Understanding Virtual Memory" article cited when motivating the setting for overcommit_memory had the meaning of
the values 1 and 2 reversed. I found it while reading this comment http://superuser.com/a/200504.

With this commit, I'm trying to make this known to the Redis FAQ reader. The proc(5) man page has it pretty clear:

       /proc/sys/vm/overcommit_memory
              This file contains the kernel virtual memory accounting mode.
              Values are:

                     0: heuristic overcommit (this is the default)
                     1: always overcommit, never check
                     2: always check, never overcommit

              In mode 0, calls of mmap(2) with MAP_NORESERVE are not
              checked, and the default check is very weak, leading to the
              risk of getting a process "OOM-killed".  Under Linux 2.4 any
              nonzero value implies mode 1.  In mode 2 (available since
              Linux 2.6), the total virtual address space on the system is
              limited to (SS + RAM*(r/100)), where SS is the size of the
              swap space, and RAM is the size of the physical memory, and r
              is the contents of the file /proc/sys/vm/overcommit_ratio.