### PR TITLE
fixed name/repo for "PHP Memory Cacher"

### DIFF
--- a/clients.json
+++ b/clients.json
@@ -339,9 +339,9 @@
   },
 
   {
-    "name": "RedisServer",
+    "name": "PHP Memory Cacher",
     "language": "PHP",
-    "repository": "https://github.com/jamm/Memory/blob/master/RedisServer.php",
+    "repository": "https://github.com/jamm/Memory/",
     "description": "Standalone and full-featured class for Redis in PHP",
     "authors": ["OZ"]
   },


### PR DESCRIPTION
Previous repo link was a 404 (for specific file, not the repo's root) and was using the filename instead of the project name.