### PR TITLE
Added Kdyby/Redis to PHP clients list

### DIFF
--- a/clients.json
+++ b/clients.json
@@ -362,6 +362,14 @@
     "description": "Lightweight, standalone, unit-tested fork of Redisent which wraps phpredis for best performance if available.",
     "authors": ["colinmollenhour"]
   },
+  {
+    "name": "Kdyby/Redis",
+    "language": "PHP",
+    "repository": "https://github.com/kdyby/redis",
+    "description": "Powerfull Redis storage for Nette Framework",",
+    "authors": ["hosiplan"]
+    "active": true
+  },
 
   {
     "name": "redis-py",


### PR DESCRIPTION
Kdyby/Redis is a powerfull caching and session storage for Nette Framework, including metadata journals (like tags and priorities) that could be used for invalidating the data.

- There is not much to fix, because it mostly just works https://github.com/Kdyby/Redis/pulse
- And community is loving it https://packagist.org/packages/kdyby/redis