### PR TITLE
Add note to restart redis after `vm.overcommit_memory` changes

### DIFF
--- a/topics/admin.md
+++ b/topics/admin.md
@@ -8,7 +8,7 @@ Redis setup hints
 -----------------
 
 + We suggest deploying Redis using the **Linux operating system**. Redis is also tested heavily on osx, and tested from time to time on FreeBSD and OpenBSD systems. However Linux is where we do all the major stress testing, and where most production deployments are working.
-+ Make sure to set the Linux kernel **overcommit memory setting to 1**. Add `vm.overcommit_memory = 1` to `/etc/sysctl.conf` and then reboot or run the command `sysctl vm.overcommit_memory=1` for this to take effect immediately.
++ Make sure to set the Linux kernel **overcommit memory setting to 1**. Add `vm.overcommit_memory = 1` to `/etc/sysctl.conf` and then reboot the machine, or run the command `sysctl vm.overcommit_memory=1` and restart Redis for this to take effect immediately.
 + Make sure to **setup some swap** in your system (we suggest as much as swap as memory). If Linux does not have swap and your Redis instance accidentally consumes too much memory, either Redis will crash for out of memory or the Linux kernel OOM killer will kill the Redis process.
 + If you are using Redis in a very write-heavy application, while saving an RDB file on disk or rewriting the AOF log **Redis may use up to 2 times the memory normally used**. The additional memory used is proportional to the number of memory pages modified by writes during the saving process, so it is often proportional to the number of keys (or aggregate types items) touched during this time. Make sure to size your memory accordingly.
 + Even if you have persistence disabled, Redis will need to perform RDB saves if you use replication.


### PR DESCRIPTION
Redis needs to be restarted after a sysctl `vm.overcommit_memory` change to take effect.

I ran into this problem yesterday with @andrewgross, and it took us a long time to realize that months ago, when sysctl was changed, Redis was running and wasn't restarted after the change.
