### PR TITLE
Add scripting docu

### DIFF
--- a/commands/eval.md
+++ b/commands/eval.md
@@ -481,14 +481,94 @@ The Redis Lua interpreter loads the following Lua libraries:
 * string lib.
 * math lib.
 * debug lib.
+* struct lib.
 * cjson lib.
 * cmsgpack lib.
+* redis.sha1hex function.
 
 Every Redis instance is _guaranteed_ to have all the above libraries so you can
 be sure that the environment for your Redis scripts is always the same.
 
-The CJSON library provides extremely fast JSON maniplation within Lua.
-All the other libraries are standard Lua libraries.
+struct, CJSON and cmsgpack are external libraries, all the other libraries are standard
+Lua libraries.
+
+### struct
+
+struct is a library for packing/unpacking structures within Lua.
+
+```
+Valid formats:
+> - big endian
+< - little endian
+![num] - alignment
+x - pading
+b/B - signed/unsigned byte
+h/H - signed/unsigned short
+l/L - signed/unsigned long
+T   - size_t
+i/In - signed/unsigned integer with size `n' (default is size of int)
+cn - sequence of `n' chars (from/to a string); when packing, n==0 means
+     the whole string; when unpacking, n==0 means use the previous
+     read number as the string length
+s - zero-terminated string
+f - float
+d - double
+' ' - ignored
+```
+
+
+Example:
+
+```
+127.0.0.1:6379> eval 'return struct.pack("HH", 1, 2)' 0
+"\x01\x00\x02\x00"
+3) (integer) 5
+127.0.0.1:6379> eval 'return {struct.unpack("HH", ARGV[1])}' 0 "\x01\x00\x02\x00"
+1) (integer) 1
+2) (integer) 2
+3) (integer) 5
+127.0.0.1:6379> eval 'return struct.size("HH")' 0
+(integer) 4
+```
+
+### CJSON
+
+The CJSON library provides extremely fast JSON manipulation within Lua.
+
+Example:
+
+```
+redis 127.0.0.1:6379> eval 'return cjson.encode({["foo"]= "bar"})' 0
+"{\"foo\":\"bar\"}"
+redis 127.0.0.1:6379> eval 'return cjson.decode(ARGV[1])["foo"]' 0 "{\"foo\":\"bar\"}"
+"bar"
+```
+
+### cmsgpack
+
+The cmsgpack library provides simple and fast MessagePack manipulation within Lua.
+
+Example:
+
+```
+127.0.0.1:6379> eval 'return cmsgpack.pack({"foo", "bar", "baz"})' 0
+"\x93\xa3foo\xa3bar\xa3baz"
+127.0.0.1:6379> eval 'return cmsgpack.unpack(ARGV[1])' 0 "\x93\xa3foo\xa3bar\xa3baz
+1) "foo"
+2) "bar"
+3) "baz"
+```
+
+### redis.sha1hex
+
+Perform the SHA1 of the input string.
+
+Example:
+
+```
+127.0.0.1:6379> eval 'return redis.sha1hex(ARGV[1])' 0 "foo"
+"0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33"
+```
 
 ## Emitting Redis logs from scripts
 


### PR DESCRIPTION
Right now the [eval](http://redis.io/commands/eval) page lists that cjson and cmsgpack are included, but it does not show how to use them.
Same goes for `redis.sha1hex`.

These should be added to the docu (I will do so tomorrow/sunday, so expect this issue to change to a PR)
