### PR TITLE
Update link to example 2.8 redis.conf in config set command documentatio...

### DIFF
--- a/commands/config set.md
+++ b/commands/config set.md
@@ -14,7 +14,7 @@ All the supported parameters have the same meaning of the equivalent
 configuration parameter used in the [redis.conf][hgcarr22rc] file, with the
 following important differences:
 
-[hgcarr22rc]: http://github.com/antirez/redis/raw/2.2/redis.conf
+[hgcarr22rc]: http://github.com/antirez/redis/raw/2.8/redis.conf
 
 * Where bytes or other quantities are specified, it is not possible to use
   the `redis.conf` abbreviated form (10k 2gb ... and so forth), everything


### PR DESCRIPTION
...n

Maybe it is time to update the documentation to point to the example redis.conf of the stable (2.8) version.
