### PR TITLE
fixing doc typos

### DIFF
--- a/topics/replication.md
+++ b/topics/replication.md
@@ -6,46 +6,47 @@ replication that allows slave Redis servers to be exact copies of
 master servers. The following are some very important facts about Redis
 replication:
 
-* Redis uses asynchronous replication. Starting with Redis 2.8 there is however a periodic (one time every second) acknowledge of the replication stream processed by slaves.
+* Redis uses asynchronous replication. Starting with Redis 2.8, however, slaves
+will periodically acknowledge the replication stream.
 
 * A master can have multiple slaves.
 
-* Slaves are able to accept other slaves connections. Aside from
+* Slaves are able to accept connections from other slaves. Aside from
 connecting a number of slaves to the same master, slaves can also be
 connected to other slaves in a graph-like structure.
 
-* Redis replication is non-blocking on the master side, this means that
-the master will continue to serve queries when one or more slaves perform
-the first synchronization.
+* Redis replication is non-blocking on the master side. This means that
+the master will continue to handle queries when one or more slaves perform
+the initial synchronization.
 
-* Replication is non blocking on the slave side: while the slave is performing
-the first synchronization it can reply to queries using the old version of
-the data set, assuming you configured Redis to do so in redis.conf.
-Otherwise you can configure Redis slaves to send clients an error if the
-link with the master is down. However there is a moment where the old dataset must be deleted and the new one must be loaded by the slave where it will block incoming connections.
+* Replication is also non-blocking on the slave side. While the slave is performing
+the initial synchronization, it can handle queries using the old version of
+the dataset, assuming you configured Redis to do so in redis.conf.
+Otherwise, you can configure Redis slaves to return an error to clients if the
+replication stream is down. However, after the initial sync, the old dataset
+must be deleted and the new one must be loaded. The slave will block incoming
+connections during this brief window.
 
-* Replications can be used both for scalability, in order to have
+* Replication can be used both for scalability, in order to have
 multiple slaves for read-only queries (for example, heavy `SORT`
-operations can be offloaded to slaves, or simply for data redundancy.
+operations can be offloaded to slaves), or simply for data redundancy.
 
-* It is possible to use replication to avoid the saving process on the
-master side: just configure your master redis.conf to avoid saving
-(just comment all the "save" directives), then connect a slave
+* It is possible to use replication to avoid the cost of writing the master
+write the full dataset to disk: just configure your master redis.conf to avoid
+saving (just comment all the "save" directives), then connect a slave
 configured to save from time to time.
 
 How Redis replication works
 ---
 
-If you set up a slave, upon connection it sends a SYNC command. And
-it doesn't matter if it's the first time it has connected or if it's
-a reconnection.
+If you set up a slave, upon connection it sends a SYNC command. It doesn't
+matter if it's the first time it has connected or if it's a reconnection.
 
-The master then starts background saving, and collects all new
+The master then starts background saving, and starts to buffer all new
 commands received that will modify the dataset. When the background
 saving is complete, the master transfers the database file to the slave,
 which saves it on disk, and then loads it into memory. The master will
-then send to the slave all accumulated commands, and all new commands
-received from clients that will modify the dataset. This is done as a
+then send to the slave all buffered commands. This is done as a
 stream of commands and is in the same format of the Redis protocol itself.
 
 You can try it yourself via telnet. Connect to the Redis port while the
@@ -59,7 +60,7 @@ concurrent slave synchronization requests, it performs a single
 background save in order to serve all of them.
 
 When a master and a slave reconnects after the link went down, a full resync
-is always performed. However starting with Redis 2.8, a partial resynchronization
+is always performed. However, starting with Redis 2.8, a partial resynchronization
 is also possible.
 
 Partial resynchronization
@@ -69,20 +70,17 @@ Starting with Redis 2.8, master and slave are usually able to continue the
 replication process without requiring a full resynchronization after the
 replication link went down.
 
-This works using an in-memory backlog of the replication stream in the
-master side. Also the master and all the slaves agree on a *replication
+This works by creating an in-memory backlog of the replication stream on the
+master side. The master and all the slaves agree on a *replication
 offset* and a *master run id*, so when the link goes down, the slave will
-reconnect and ask the master to continue the replication, assuming the
+reconnect and ask the master to continue the replication. Assuming the
 master run id is still the same, and that the offset specified is available
-in the replication backlog.
-
-If the conditions are met, the master just sends the part of the replication
-stream the master missed, and the replication continues.
-Otherwise a full resynchronization is performed as in the past versions of
-Redis.
+in the replication backlog, replication will resume from the point where it left off.
+If either of these conditions are unmet, a full resynchronization is performed
+(which is the normal pre-2.8 behavior).
 
 The new partial resynchronization feature uses the `PSYNC` command internally,
-while the old implementation used the `SYNC` command, however a Redis 2.8
+while the old implementation uses the `SYNC` command. Note that a Redis 2.8
 slave is able to detect if the server it is talking with does not support
 `PSYNC`, and will use `SYNC` instead.
 
@@ -98,19 +96,19 @@ Of course you need to replace 192.168.1.1 6379 with your master IP address (or
 hostname) and port. Alternatively, you can call the `SLAVEOF` command and the
 master host will start a sync with the slave.
 
-There are also a few parameters in order to tune the replication backlog taken
+There are also a few parameters for tuning the replication backlog taken
 in memory by the master to perform the partial resynchronization. See the example
 `redis.conf` shipped with the Redis distribution for more information.
 
-Read only slave
+Read-only slave
 ---
 
-Since Redis 2.6 slaves support a read-only mode that is enabled by default.
+Since Redis 2.6, slaves support a read-only mode that is enabled by default.
 This behavior is controlled by the `slave-read-only` option in the redis.conf file, and can be enabled and disabled at runtime using `CONFIG SET`.
 
-Read only slaves will reject all the write commands, so that it is not possible to write to a slave because of a mistake. This does not mean that the feature is conceived to expose a slave instance to the internet or more generally to a network where untrusted clients exist, because administrative commands like `DEBUG` or `CONFIG` are still enabled. However security of read-only instances can be improved disabling commands in redis.conf using the `rename-command` directive.
+Read-only slaves will reject all write commands, so that it is not possible to write to a slave because of a mistake. This does not mean that the feature is intended to expose a slave instance to the internet or more generally to a network where untrusted clients exist, because administrative commands like `DEBUG` or `CONFIG` are still enabled. However, security of read-only instances can be improved by disabling commands in redis.conf using the `rename-command` directive.
 
-You may wonder why it is possible to revert the default and have slave instances that can be target of write operations. The reason is that while this writes will be discarded if the slave and the master will resynchronize, or if the slave is restarted, often there is ephemeral data that is unimportant that can be stored into slaves. For instance clients may take information about reachability of master in the slave instance to coordinate a fail over strategy.
+You may wonder why it is possible to revert the read-only setting and have slave instances that can be target of write operations. The reason is that these writes will be discarded if the slave and the master resynchronize, or if the slave is restarted. Often there is ephemeral data that is unimportant that can be stored on read-only slaves. For instance, clients may take information about master reachability to coordinate a failover strategy.
 
 Setting a slave to authenticate to a master
 ---
@@ -129,12 +127,12 @@ To set it permanently, add this to your config file:
 Allow writes only with N attached replicas
 ---
 
-Starting with Redis 2.8 it is possible to configure a Redis master in order to
+Starting with Redis 2.8, it is possible to configure a Redis master to
 accept write queries only if at least N slaves are currently connected to the
-master, in order to improve data safety.
+master.
 
-However because Redis uses asynchronous replication it is not possible to ensure
-the write actually received a given write, so there is always a window for data
+However, because Redis uses asynchronous replication it is not possible to ensure
+the slave actually received a given write, so there is always a window for data
 loss.
 
 This is how the feature works:
@@ -154,5 +152,5 @@ There are two configuration parameters for this feature:
 * min-slaves-to-write `<number of slaves>`
 * min-slaves-max-lag `<number of seconds>`
 
-For more information please check the example `redis.conf` file shipped with the
+For more information, please check the example `redis.conf` file shipped with the
 Redis source distribution.


### PR DESCRIPTION
I started fixing typos when I noticed this mistake in the current version of the docs:

```
If the conditions are met, the master just sends the part of the replication stream the master missed, and the replication continues. Otherwise a full resynchronization is performed as in the past versions of Redis.
```

That should have read "the part of the replication stream the slave missed". I fixed that mistake, and cleaned up some wording and typos on the rest of the page.
