### PR TITLE
Update time complexity of LRANGE

### DIFF
--- a/commands.json
+++ b/commands.json
@@ -893,7 +893,7 @@
   },
   "LRANGE": {
     "summary": "Get a range of elements from a list",
-    "complexity": "O(S+N) where S is the start offset and N is the number of elements in the specified range.",
+    "complexity": "O(S+N) where S is the distance of start offset from HEAD for small lists, from nearest end (HEAD or TAIL) for large lists; and N is the number of elements in the specified range.",
     "arguments": [
       {
         "name": "key",


### PR DESCRIPTION
LRANGE for LinkedLists traverses from nearest end and not always HEAD (as with ZipLists). Tries to make this behaviour clear.  

A client actually asked us about LRANGE -10 -1 on a million-entries list; we found this nice optimization upon looking at the [source](https://github.com/antirez/redis/blob/2eb781b35bfa9bde5ab88b192cd3e666e7872625/src/t_list.c#L575).
