### PR TITLE
Fix typo in bitpos command descriptions

### DIFF
--- a/commands/bitpos.md
+++ b/commands/bitpos.md
@@ -29,7 +29,7 @@ If we look for clear bits (the bit argument is 0) and the string only contains b
 
 Basically the function consider the right of the string as padded with zeros if you look for clear bits and specify no range or the _start_ argument **only**.
 
-However this behavior changes if you are looking for clear bits and specify a range with bot __start__ and __end__. If no clear bit is found in the specified range, the function returns -1 as the user specified a clear range and there are no 0 bits in that range.
+However this behavior changes if you are looking for clear bits and specify a range with both __start__ and __end__. If no clear bit is found in the specified range, the function returns -1 as the user specified a clear range and there are no 0 bits in that range.
 
 @examples
 


### PR DESCRIPTION
I've fixed one typo.

---

However this behavior changes if you are looking for clear bits and specify a range with bot (=> both) **start** and **end**.
