### PR TITLE
Updated Dart client link.

### DIFF
--- a/clients.json
+++ b/clients.json
@@ -517,7 +517,7 @@
   {
     "name": "DartRedisClient",
     "language": "Dart",
-    "url": "https://github.com/mythz/DartRedisClient",
+    "url": "https://github.com/dartist/redis_client",
     "description": "A high-performance async/non-blocking Redis client for Dart",
     "authors": ["demisbellot"],
     "recommended": true,


### PR DESCRIPTION
The authoritative repository changed, just adding the most recent URL.