### PR TITLE
Add link to Perl implementation

### DIFF
--- a/topics/distlock.md
+++ b/topics/distlock.md
@@ -26,6 +26,7 @@ already available, that can be used as a reference.
 * [Redlock-rb](https://github.com/antirez/redlock-rb) (Ruby implementation).
 * [Redlock-php](https://github.com/ronnylt/redlock-php) (PHP implementation).
 * [Redsync.go](https://github.com/hjr265/redsync.go) (Go implementation).
+* [Redis::DistLock](https://github.com/sbertrang/redis-distlock) (Perl implementation).
 
 Safety and Liveness guarantees
 ---


### PR DESCRIPTION
This commit adds a link to a Perl implementation of Redlock.
Thanks for making pretty, clean and effective distributed locks possible!

Cheers,
Simon
