### PR TITLE
Add gore to client.json

### DIFF
--- a/clients.json
+++ b/clients.json
@@ -157,6 +157,15 @@
   },
 
   {
+    "name": "gore",
+    "language": "Go",
+    "repository": "https://github.com/keimoon/gore",
+    "description": "A full feature redis Client for Go. Supports Pipeline, Transaction, LUA scripting, Pubsub, Connection Pool, Sentinel and client sharding",
+    "authors": ["keimoon"],
+    "active": true
+  },
+
+  {
     "name": "hedis",
     "language": "Haskell",
     "url": "http://hackage.haskell.org/package/hedis",


### PR DESCRIPTION
Add gore (https://github.com/keimoon/gore) to client list
Gore is a full feature Redis client for Go that supports Pipeline, Transaction, LUA scripting, Pubsub, Connection Pool, Sentinel and client sharding
