### PR TITLE
Please add java implementation reference of distributed lock 

### DIFF
--- a/topics/distlock.md
+++ b/topics/distlock.md
@@ -26,6 +26,7 @@ already available, that can be used as a reference.
 * [Redlock-rb](https://github.com/antirez/redlock-rb) (Ruby implementation).
 * [Redlock-php](https://github.com/ronnylt/redlock-php) (PHP implementation).
 * [Redsync.go](https://github.com/hjr265/redsync.go) (Go implementation).
+* [Redisson](https://github.com/mrniko/redisson) (Java implementation).
 
 Safety and Liveness guarantees
 ---


### PR DESCRIPTION
[Redisson](https://github.com/mrniko/redisson) added as java implementation of distributed lock with TTL support.
