### PR TITLE
Add docs: CLUSTER SLOTS, COMMAND

### DIFF
--- a/commands.json
+++ b/commands.json
@@ -227,6 +227,43 @@
     ],
     "group": "server"
   },
+  "CLUSTER SLOTS": {
+    "summary": "Get array of Cluster slot to node mappings",
+    "complexity": "O(N) where N is the total number of Cluster nodes",
+    "since": "3.0.0",
+    "group": "server"
+  },
+  "COMMAND": {
+    "summary": "Get array of Redis command details",
+    "complexity": "O(N) where N is the total number of Redis commands",
+    "since": "2.8.13",
+    "group": "server"
+  },
+  "COMMAND COUNT": {
+    "summary": "Get total number of Redis commands",
+    "complexity": "O(1)",
+    "since": "2.8.13",
+    "group": "server"
+  },
+  "COMMAND GETKEYS": {
+    "summary": "Extract keys given a full Redis command",
+    "complexity": "O(N) where N is the number of arugments to the command",
+    "since": "2.8.13",
+    "group": "server"
+  },
+  "COMMAND INFO": {
+    "summary": "Get array of specific Redis command details",
+    "complexity": "O(N) when N is number of commands to look up",
+    "since": "2.8.13",
+    "arguments": [
+      {
+        "name": "command-name",
+        "type": "string",
+        "multiple": true
+      }
+    ],
+    "group": "server"
+  },
   "CONFIG GET": {
     "summary": "Get the value of a configuration parameter",
     "arguments": [

--- a/commands/cluster slots.md
+++ b/commands/cluster slots.md
@@ -1,0 +1,59 @@
+Returns @array-reply of current cluster state.
+
+`CLUSTER SLOTS` returns details about which cluster slots map to which
+Redis instances.
+
+## Nested Result Array
+Each nested result is:
+
+  - Start slot range
+  - End slot range
+  - Master for slot range represented as nested IP/Port array 
+  - First replica of master for slot range
+  - Second replica
+  - ...continues until all replicas for this master are returned.
+
+Each result includes all active replicas of the master instance
+for the listed slot range.  Failed replicas are not returned.
+
+The third nested reply is guaranteed to be the IP/Port pair of
+the master instance for the slot range.
+All IP/Port pairs after the third nested reply are replicas
+of the master.
+
+If a cluster instance has non-contiguous slots (e.g. 1-400,900,1800-6000) then
+master and replica IP/Port results will be duplicated for each top-level
+slot range reply.
+
+### Sample Output
+```
+127.0.0.1:7001> cluster slots
+1) 1) (integer) 0
+   2) (integer) 4095
+   3) 1) "127.0.0.1"
+      2) (integer) 7000
+   4) 1) "127.0.0.1"
+      2) (integer) 7004
+2) 1) (integer) 12288
+   2) (integer) 16383
+   3) 1) "127.0.0.1"
+      2) (integer) 7003
+   4) 1) "127.0.0.1"
+      2) (integer) 7007
+3) 1) (integer) 4096
+   2) (integer) 8191
+   3) 1) "127.0.0.1"
+      2) (integer) 7001
+   4) 1) "127.0.0.1"
+      2) (integer) 7005
+4) 1) (integer) 8192
+   2) (integer) 12287
+   3) 1) "127.0.0.1"
+      2) (integer) 7002
+   4) 1) "127.0.0.1"
+      2) (integer) 7006
+```
+
+@return
+
+@array-reply: nested list of slot ranges with IP/Port mappings.

--- a/commands/command count.md
+++ b/commands/command count.md
@@ -1,0 +1,11 @@
+Returns @integer-reply of number of total commands in this Redis server.
+
+@return
+
+@integer-reply: number of commands returned by `COMMAND`
+
+@examples
+
+```cli
+COMMAND COUNT
+```

--- a/commands/command getkeys.md
+++ b/commands/command getkeys.md
@@ -1,0 +1,22 @@
+Returns @array-reply of keys from a full Redis command.
+
+`COMMAND GETKEYS` is a helper command to let you find the keys
+from a full Redis command.
+
+`COMMAND` shows some commands as having movablekeys meaning
+the entire command must be parsed to discover storage or retrieval
+keys.  You can use `COMMAND GETKEYS` to discover key positions
+directly from how Redis parses the commands.
+
+
+@return
+
+@array-reply: list of keys from your command.
+
+@examples
+
+```cli
+COMMAND GETKEYS MSET a b c d e f
+COMMAND GETKEYS EVAL "not consulted" 3 key1 key2 key3 arg1 arg2 arg3 argN
+COMMAND GETKEYS SORT mylist ALPHA STORE outlist
+```

--- a/commands/command info.md
+++ b/commands/command info.md
@@ -1,0 +1,19 @@
+Returns @array-reply of details about multiple Redis commands.
+
+Same result format as `COMMAND` except you can specify which commands
+get returned.
+
+If you request details about non-existing commands, their return
+position will be nil.
+
+
+@return
+
+@array-reply: nested list of command details.
+
+@examples
+
+```cli
+COMMAND INFO get set eval
+COMMAND INFO foo evalsha config bar
+```

--- a/commands/command.md
+++ b/commands/command.md
@@ -1,0 +1,178 @@
+Returns @array-reply of details about all Redis commands.
+
+Cluster clients must be aware of key positions in commands so commands can go to matching instances,
+but Redis commands vary between accepting one key,
+multiple keys, or even multiple keys separated by other data.
+
+You can use `COMMAND` to cache a mapping between commands and key positions for
+each command to enable exact routing of commands to cluster instances.
+
+## Nested Result Array
+Each top-level result contains six nested results.  Each nested result is:
+
+  - command name
+  - command arity specification
+  - nested @array-reply of command flags
+  - position of first key in argument list
+  - position of last key in argument list
+  - step count for locating repeating keys
+
+### Command Name
+
+Command name is the command returned as a lowercase string.
+
+### Command Arity
+
+<table style="width:50%">
+<tr><td>
+<pre>
+<code>1) 1) "get"
+   2) (integer) 2
+   3) 1) readonly
+   4) (integer) 1
+   5) (integer) 1
+   6) (integer) 1
+</code>
+</pre>
+</td>
+<td>
+<pre>
+<code>1) 1) "mget"
+   2) (integer) -2
+   3) 1) readonly
+   4) (integer) 1
+   5) (integer) -1
+   6) (integer) 1
+</code>
+</pre>
+</td></tr>
+</table>
+
+Command arity follows a simple pattern:
+
+  - positive if command has fixed number of required arguments.
+  - negative if command has minimum number of required arguments, but may have more.
+
+Command arity _includes_ counting the command name itself.
+
+Examples:
+
+  - `GET` arity is 2 since the command only accepts one
+argument and always has the format `GET _key_`.
+  - `MGET` arity is -2 since the command accepts at a minimum
+one argument, but up to an unlimited number: `MGET _key1_ [key2] [key3] ...`.
+
+Also note with `MGET`, the -1 value for "last key position" means the list
+of keys may have unlimited length.
+
+### Flags
+Command flags is @array-reply containing one or more status replies:
+
+  - *write* - command may result in modifications
+  - *readonly* - command will never modify keys
+  - *denyoom* - reject command if currently OOM
+  - *admin* - server admin command
+  - *pubsub* - pubsub-related command
+  - *noscript* - deny this command from scripts
+  - *random* - command has random results, dangerous for scripts
+  - *sort\_for\_script* - if called from script, sort output
+  - *loading* - allow command while database is loading
+  - *stale* - allow command while replica has stale data
+  - *skip_monitor* - do not show this command in MONITOR
+  - *asking* - cluster related - accept even if importing
+  - *fast* - command operates in constant or log(N) time.  Used for latency monitoring.
+  - *movablekeys* - keys have no pre-determined position.  You must discover keys yourself.
+
+
+### Movable Keys
+
+```
+1) 1) "sort"
+   2) (integer) -2
+   3) 1) write
+      2) denyoom
+      3) movablekeys
+   4) (integer) 1
+   5) (integer) 1
+   6) (integer) 1
+```
+
+Some Redis commands have no predetermined key locations.  For those commands,
+flag `movablekeys` is added to the command flags @array-reply.  Your Redis
+Cluster client needs to parse commands marked `movabkeleys` to locate all relevant key positions.
+
+Complete list of commands currently requiring key location parsing:
+
+  - `SORT` - optional `STORE` key, optional `BY` weights, optional `GET` keys
+  - `ZUNIONSTORE` - keys stop when `WEIGHT` or `AGGREGATE` starts
+  - `ZINTERSTORE` - keys stop when `WEIGHT` or `AGGREGATE` starts
+  - `EVAL` - keys stop after `numkeys` count arguments
+  - `EVALSHA` - keys stop after `numkeys` count arguments
+
+Also see `COMMAND GETKEYS` for getting your Redis server tell you where keys
+are in any given command.
+
+### First Key in Argument List
+
+For most commands the first key is position 1.  Position 0 is
+always the command name itself.
+
+
+### Last Key in Argument List
+
+Redis commands usually accept one key, two keys, or an unlimited number of keys.
+
+If a command accepts one key, the first key and last key positions is 1.
+
+If a command accepts two keys (e.g. `BRPOPLPUSH`, `SMOVE`, `RENAME`, ...) then the
+last key position is the location of the last key in the argument list.
+
+If a command accepts an unlimited number of keys, the last key position is -1.
+
+
+### Step Count
+
+<table style="width:50%">
+<tr><td>
+<pre>
+<code>1) 1) "mset"
+   2) (integer) -3
+   3) 1) write
+      2) denyoom
+   4) (integer) 1
+   5) (integer) -1
+   6) (integer) 2
+</code>
+</pre>
+</td>
+<td>
+<pre>
+<code>1) 1) "mget"
+   2) (integer) -2
+   3) 1) readonly
+   4) (integer) 1
+   5) (integer) -1
+   6) (integer) 1
+</code>
+</pre>
+</td></tr>
+</table>
+
+Key step count allows us to find key positions in commands
+like `MSET` where the format is `MSET _key1_ _val1_ [key2] [val2] [key3] [val3]...`.
+
+In the case of `MSET`, keys are every other position so the step value is 2.  Compare
+with `MGET` above where the step value is just 1.
+
+
+
+@return
+
+@array-reply: nested list of command details.  Commands are returned
+in random order.
+
+@examples
+
+```cli
+COMMAND
+```


### PR DESCRIPTION
COMMAND docs include individual pages for:
- COMMAND COUNT
- COMMAND GETKEYS
- COMMAND INFO

If you prefer an individual commit for `CLUSTER SLOTS` vs. `COMMAND`, let me know and I'll split it out.

Also: during testing for the on-site REPL, I discovered the getKeys function for SORT is still broken.  :-\   I'm looking into why it doesn't capture the `STORE` argument.  It used to work, but then we fixed it to un-work.
