### PR TITLE
Add rediscala, a non-blocking I/O scala driver

### DIFF
--- a/clients.json
+++ b/clients.json
@@ -486,6 +486,15 @@
     "authors": ["livestream"],
     "active": true
   },
+  
+  {
+    "name": "rediscala",
+    "language": "Scala",
+    "repository": "https://github.com/etaty/rediscala",
+    "description": "A Redis client for Scala (2.10+) and (AKKA 2.2+) with non-blocking and asynchronous I/O operations.",
+    "authors": ["etaty"],
+    "active": true
+  },
 
   {
     "name": "Tcl Client",


### PR DESCRIPTION
A non-blocking I/O scala driver is very useful for async frameworks (like Play)
