### PR TITLE
Changed repository of Tideland Go client

### DIFF
--- a/clients.json
+++ b/clients.json
@@ -122,7 +122,7 @@
   {
     "name": "Tideland Go Redis Client",
     "language": "Go",
-    "repository": "http://git.tideland.biz/godm/redis",
+    "repository": "https://github.com/tideland/godm",
     "description": "A flexible Go Redis client able to handle all commands",
     "authors": ["themue"],
     "active": true


### PR DESCRIPTION
The Tideland Go software moved to GitHub. So changed the repository here.
