### PR TITLE
bitcount has optional, but not multiple arguments

### DIFF
--- a/commands.json
+++ b/commands.json
@@ -47,7 +47,7 @@
       {
         "name": ["start", "end"],
         "type": ["integer", "integer"],
-        "multiple": true
+        "optional": true
       }
     ],
     "since": "2.6.0",


### PR DESCRIPTION
`BITCOUNT` can be used with 1 or 3 arguments. Not multiple arguments for start/stop.
