### PR TITLE
Update redis.conf links

### DIFF
--- a/topics/config.md
+++ b/topics/config.md
@@ -26,8 +26,9 @@ The list of configuration directives, and their meaning and intended usage
 is available in the self documented example redis.conf shipped into the
 Redis distribution.
 
-* The self documented [redis.conf for Redis 2.6](https://raw.github.com/antirez/redis/2.6/redis.conf).
-* The self documented [redis.conf for Redis 2.4](https://raw.github.com/antirez/redis/2.4/redis.conf).
+* The self documented [redis.conf for Redis 2.8](https://raw.githubusercontent.com/antirez/redis/2.8/redis.conf)
+* The self documented [redis.conf for Redis 2.6](https://raw.githubusercontent.com/antirez/redis/2.6/redis.conf).
+* The self documented [redis.conf for Redis 2.4](https://raw.githubusercontent.com/antirez/redis/2.4/redis.conf).
 
 Passing arguments via the command line
 ---


### PR DESCRIPTION
Update redis.conf links:
- Fix links for older versions
- Add link for redis 2.8
