### PR TITLE
Updating description for the gosexy/redis package.

### DIFF
--- a/clients.json
+++ b/clients.json
@@ -142,7 +142,7 @@
     "language": "Go",
     "repository": "https://github.com/gosexy/redis",
     "url": "https://menteslibres.net/gosexy/redis",
-    "description": "A Go client for redis built on top of the hiredis C client. Supports non-blocking connections and channel-based subscriptions.",
+    "description": "Redis client library for Go that maps the full redis command list into equivalent Go functions.",
     "authors": ["xiam"],
     "active": true
   },


### PR DESCRIPTION
The former description was not valid anymore, as we have removed dependency on hiredis by creating two packages: a RESP encoder/decoder and a Redis client library that uses the RESP encoder/decoder.