### PR TITLE
Recommend redis-rs and reorder the rust libraries.

### DIFF
--- a/clients.json
+++ b/clients.json
@@ -778,6 +778,16 @@
     "description": "A Redis client written with the Akka IO package introduced in Akka 2.2.",
     "authors": ["chrisdinn"]
   },
+
+  {
+    "name": "redis-rs",
+    "language": "Rust",
+    "repository": "https://github.com/mitsuhiko/redis-rs",
+    "description": "A high and low level client library for Redis tracking Rust nightly.",
+    "authors": ["mitsuhiko"],
+    "active": true,
+    "recommended": true
+  },
   
   {
     "name": "rust-redis",
@@ -785,15 +795,6 @@
     "repository": "https://github.com/mneumann/rust-redis",
     "description": "A Rust client library for Redis.",
     "authors": ["mneumann"],
-    "active": true
-  },
-
-  {
-    "name": "redis-rs",
-    "language": "Rust",
-    "repository": "https://github.com/mitsuhiko/redis-rs",
-    "description": "A fairly high level client library for Redis.",
-    "authors": ["mitsuhiko"],
     "active": true
   },
 


### PR DESCRIPTION
redis-rs is currently the only library that works with any recent rust version or is maintained.