### PR TITLE
`SCRIPT` isn't allowed by web-embedded Redis

### DIFF
--- a/commands/script exists.md
+++ b/commands/script exists.md
@@ -17,10 +17,3 @@ Lua scripting.
 the specified SHA1 digest arguments.
 For every corresponding SHA1 digest of a script that actually exists in the
 script cache, an 1 is returned, otherwise 0 is returned.
-
-@example
-
-```cli
-SCRIPT LOAD "return 1"
-SCRIPT EXISTS e0e1f9fabfc9d4800c877a703b823ac0578ff8db
-```


### PR DESCRIPTION
The example doesn't work and returns two errors.