### PR TITLE
Add redox to C++ clients in clients.json

### DIFF
--- a/clients.json
+++ b/clients.json
@@ -747,6 +747,15 @@
   },
 
   {
+    "name": "redox",
+    "language": "C++",
+    "repository": "https://github.com/hmartiro/redox",
+    "description": "Modern, asynchronous, and fast C++11 client for Redis",
+    "authors": ["hmartiros"],
+    "active": true
+  },
+  
+  {
     "name": "redis3m",
     "language": "C++",
     "repository": "https://github.com/luca3m/redis3m",


### PR DESCRIPTION
Redox is a modern, asynchronous, and fast C++11 client for Redis. It's new, but I think the API has a lot of promise and the performance is great. Can you add it?

Thanks,
Hayk