### PR TITLE
Add Hash to question about max number of elements

### DIFF
--- a/topics/faq.md
+++ b/topics/faq.md
@@ -123,12 +123,12 @@ start thinking at some way to shard earlier.
 
 You can find more information about using multiple Redis instances in the [Partitioning page](/topics/partitioning).
 
-## What is the maximum number of keys a single Redis instance can hold? and what the max number of elements in a List, Set, Sorted Set?
+## What is the maximum number of keys a single Redis instance can hold? and what the max number of elements in a Hash, List, Set, Sorted Set?
 
 Redis can handle up to 2^32 keys, and was tested in practice to
 handle at least 250 million of keys per instance.
 
-Every list, set, and sorted set, can hold 2^32 elements.
+Every hash, list, set, and sorted set, can hold 2^32 elements.
 
 In other words your limit is likely the available memory in your system.
 


### PR DESCRIPTION
Since Hashes are using dict they can also have a max of ~2^32 fields.