### PR TITLE
A new C++ redis client, support all redis commands including redis3.0 cluster

### DIFF
--- a/clients.json
+++ b/clients.json
@@ -769,7 +769,7 @@
     "language": "C++",
     "url": "https://github.com/zhengshuxin/acl/tree/master/lib_acl_cpp/samples/redis",
     "repository": "https://github.com/zhengshuxin/acl/tree/master/lib_acl_cpp/include/acl_cpp/redis",
-    "description": "one redis command one redis function, including STRING, HASH, LIST, SET, ZSET, HLL, PUBSUB, TRANSACTION, SCRIPT, CONNECTION, SERVER, CLUSTER",
+    "description": "full redis client commands, one redis command one redis function, including STRING, HASH, LIST, SET, ZSET, HLL, PUBSUB, TRANSACTION, SCRIPT, CONNECTION, SERVER, CLUSTER",
     "authors": [],
     "active": true
   },

--- a/clients.json
+++ b/clients.json
@@ -765,6 +765,16 @@
   },
 
   {
+    "name": "redis-client for C++"
+    "language": "C++",
+    "url": "https://github.com/zhengshuxin/acl/tree/master/lib_acl_cpp/samples/redis",
+    "repository": "https://github.com/zhengshuxin/acl/tree/master/lib_acl_cpp/include/acl_cpp/redis",
+    "description": "one redis command one redis function, including STRING, HASH, LIST, SET, ZSET, HLL, PUBSUB, TRANSACTION, SCRIPT, CONNECTION, SERVER, CLUSTER",
+    "authors": [],
+    "active": true
+  },
+
+  {
     "name": "redox",
     "language": "C++",
     "repository": "https://github.com/hmartiro/redox",


### PR DESCRIPTION
I've completed a new C++ redis client, which support all redis commands including redis3.0 cluster. There're 12 C++ classes for 12 redis structur types, and 150+ functions for all redis commands. The redis client also supports connection pool and cluster pool.
The C++ HEADER in https://github.com/zhengshuxin/acl/tree/master/lib_acl_cpp/include/acl_cpp/redis
The samples in https://github.com/zhengshuxin/acl/tree/master/lib_acl_cpp/samples/redis
The redis cluster sample in https://github.com/zhengshuxin/acl/blob/master/lib_acl_cpp/samples/redis/redis_cluster/redis_cluster.cpp
The redis client source codes in https://github.com/zhengshuxin/acl/tree/master/lib_acl_cpp/src/redis

 The samples are below:
1)  simple example for redis string:
void test_redis_string(acl::redis_string& cmd, const char* key)
{
    acl::string val("test_value");

    // call redis-server: SET key value
    if (cmd.set(key, val.c_str()) == false)
    {
        printf("redis set error\r\n");
        return;
    }

    // clear the string buf space
    val.clear();

    // reset the redis command object for reusing it
    cmd.reset();

    // call redis-server: GET key
    if (cmd.get(key, val) == false)
        printf("get key error\r\n");
}

void test_redis_key(acl::redis_key& cmd, const char* key)
{
    if (cmd_key.exists(key) == false)
        printf("key not exists\r\n");
    else
        printf("key exists\r\n");
}

void test_redis()
{
    const char* redis_addr = "127.0.0.1:6379";
    int  conn_timeout = 10, rw_timeout = 10;

    // the redis client connection
    acl::redis_client conn(redis_addr, conn_timeout, rw_timeout);

    const char* key = "test_key";

    // test redis STRING command
    // bind redis_string command with redis connection
    acl::redis_string cmd_string(&conn);
    test_redis_string(cmd_string, key);

    // test redis KEY command with the same redis connection
    acl::redis_key cmd_key(&conn);
    test_redis_key(cmd_key, key);
}

I just modify test_redis() to support redis3.0 cluster, show below:

2) redis client cluster example for redis3.0

void test_redis()
{
    const char* redis_addr = "127.0.0.1:6379";
    int  conn_timeout = 10, rw_timeout = 10, max_conns = 100;

    // declare redis cluster ojbect
    acl::redis_cluster cluster;
    cluster.set(redis_addr, max_conns);

    // redis operation command
    acl::redis_string cmd_string;
    acl::redis_key cmd_key;

    // bind redis command with redis cluster
    cmd_string.set_cluster(&cluster, max_conns);
    cmd_key.set_cluster(&cluster, max_conns);

    const char* key = "test_key";

    // call redis server
    test_redis_string(cmd_string, key);
    test_redis_key(cmd_key, key);
}
The redis cluster support caching the redis hash-slot in client for performance, and can dynamic add redis server nodes in running.