### PR TITLE
thunk-redis support redis cluster

### DIFF
--- a/clients.json
+++ b/clients.json
@@ -685,7 +685,7 @@
     "name": "thunk-redis",
     "language": "Node.js",
     "repository": "https://github.com/thunks/thunk-redis",
-    "description": "A redis client with pipelining, rely on thunks, support promise.",
+    "description": "A thunk/promise-based redis client with pipelining and cluster.",
     "authors": ["izensh"],
     "active": true
   },

--- a/topics/cluster-tutorial.md
+++ b/topics/cluster-tutorial.md
@@ -339,6 +339,7 @@ I'm aware of the following implementations:
 * The popular [Predis](https://github.com/nrk/predis) has support for Redis Cluster, the support was recently updated and is in active development.
 * The most used Java client, [Jedis](https://github.com/xetorthio/jedis) recently added support for Redis Cluster, see the *Jedis Cluster* section in the project README.
 * [StackExchange.Redis](https://github.com/StackExchange/StackExchange.Redis) offers support for C# (and should work fine with most .NET languages; VB, F#, etc)
+* [thunk-redis](https://github.com/thunks/thunk-redis) offers support for Node.js and io.js, it is a thunk/promise-based redis client with pipelining and cluster.
 * The `redis-cli` utility in the unstable branch of the Redis repository at GitHub implements a very basic cluster support when started with the `-c` switch.
 
 An easy way to test Redis Cluster is either to try and of the above clients


### PR DESCRIPTION
So update description and add to cluster-tutorial...

Benckmark in single node:
![qq20150309-1 2x](https://cloud.githubusercontent.com/assets/863754/6558554/cac3bce6-c6b7-11e4-820d-691f1989a227.png)
