### PR TITLE
Add ioredis client

### DIFF
--- a/clients.json
+++ b/clients.json
@@ -710,6 +710,16 @@
   },
 
   {
+    "name": "ioredis",
+    "language": "Node.js",
+    "repository": "https://github.com/luin/ioredis",
+    "description": "A delightful, performance-focused and full-featured Redis client. Supports Cluster, Sentinel, Pipelining and Lua Scripting",
+    "authors": ["luin"],
+    "recommended": true,
+    "active": true
+  },
+
+  {
     "name": "iodis",
     "language": "Io",
     "repository": "https://github.com/vangberg/iodis",


### PR DESCRIPTION
ioredis is a robust, full-featured Redis client used in the world's biggest online commerce company Alibaba. It supports Cluster, Sentinel, Pipelining and Lua Scripting.

Note that I add "recommended" flag to it(disclaimer: I am the author of ioredis) for the following reasons:

1. The current recommended client [node_redis](https://github.com/mranney/node_redis) is not active any more and it has some non-trivial bugs unfixed and many issues unresolved(see [issues on node_redis](https://github.com/mranney/node_redis/issues?q=is%3Aopen+is%3Aissue) and [Motivation](https://github.com/luin/ioredis#motivation)).
2. ioredis has already been used in the production environment in our company. It works very well and turns out to be faster and more robust than node_redis.
3. ioredis is the only Node.js Redis client that supports both Cluster, Sentinel, Pipelining.

Feel free to let me know if there's any questions about this pr.

Thanks for all your work on Redis!