### PR TITLE
fix typo in how Redis expires keys section

### DIFF
--- a/commands/expire.md
+++ b/commands/expire.md
@@ -137,7 +137,7 @@ Specifically this is what Redis does 10 times per second:
 
 1. Test 20 random keys from the set of keys with an associated expire.
 2. Delete all the keys found expired.
-3. If more than 25 keys were expired, start again from step 1.
+3. If more than 25% of keys were expired, start again from step 1.
 
 This is a trivial probabilistic algorithm, basically the assumption is that our
 sample is representative of the whole key space, and we continue to expire until


### PR DESCRIPTION
Here is a small typo fix in Expire command description