### PR TITLE
Added missing glob-style patterns

### DIFF
--- a/commands/keys.md
+++ b/commands/keys.md
@@ -21,6 +21,8 @@ Supported glob-style patterns:
 * `h?llo` matches `hello`, `hallo` and `hxllo`
 * `h*llo` matches `hllo` and `heeeello`
 * `h[ae]llo` matches `hello` and `hallo,` but not `hillo`
+* `h[^e]llo` matches `hallo`, `hbllo`, ... but not `hello`
+* `h[a-b]llo` matches `hallo` and `hbllo`
 
 Use `\` to escape special characters if you want to match them verbatim.
 


### PR DESCRIPTION
Specifically the character set's complement and range.

A separate pattern-matching.md topic that's linked from `KEYS` and `[HSZ]?SCAN` doc pages seems to be a good idea <- thoughts?