### PR TITLE
Correct redis-cli pipe mode : available at 2.6 or higher

### DIFF
--- a/topics/mass-insert.md
+++ b/topics/mass-insert.md
@@ -41,7 +41,7 @@ as fast as possible. In the past the way to do this was to use the
 
 However this is not a very reliable way to perform mass import because netcat
 does not really know when all the data was transferred and can't check for
-errors. At 3.0.0 or higher version of Redis the `redis-cli` utility
+errors. 2.6 or higher version of Redis the `redis-cli` utility
 supports a new mode called **pipe mode** that was designed in order to perform
 mass insertion.
 

--- a/topics/mass-insert.md
+++ b/topics/mass-insert.md
@@ -41,7 +41,7 @@ as fast as possible. In the past the way to do this was to use the
 
 However this is not a very reliable way to perform mass import because netcat
 does not really know when all the data was transferred and can't check for
-errors. In the unstable branch of Redis at github the `redis-cli` utility
+errors. At 3.0.0 or higher version of Redis the `redis-cli` utility
 supports a new mode called **pipe mode** that was designed in order to perform
 mass insertion.
 


### PR DESCRIPTION
Based on https://github.com/antirez/redis/commit/088c508abc89b66ce14870a2abe06879238a3b21, we don't need to checkout unstable branch and build by hand to use pipe mode.