### PR TITLE
Add promise-redis as Node.js client.

### DIFF
--- a/clients.json
+++ b/clients.json
@@ -719,6 +719,15 @@
   },
 
   {
+    "name": "promise-redis",
+    "language": "Node.js",
+    "repository": "https://github.com/maxbrieiev/promise-redis",
+    "description": "Use any promise library with node_redis.",
+    "authors": ["maxbrieiev"],
+    "active": true
+  },
+
+  {
     "name": "iodis",
     "language": "Io",
     "repository": "https://github.com/vangberg/iodis",


### PR DESCRIPTION
promise-redis provides means to integrate any promise library with node-redis. Please, accept this pull request.