### PR TITLE
Move package to new vendor namespace

### DIFF
--- a/clients.json
+++ b/clients.json
@@ -436,7 +436,7 @@
   {
     "name": "PHP Sentinel Client",
     "language": "PHP",
-    "repository": "https://github.com/Sparkcentral/PSRedis",
+    "repository": "https://github.com/jamescauwelier/PSRedis",
     "description": "A PHP sentinel client acting as an extension to your regular redis client",
     "authors": ["jamescauwelier"],
     "active": true


### PR DESCRIPTION
Moving the package out of the company namespace and into my personal one to ensure continued support.