### PR TITLE
Further PHP implementation

### DIFF
--- a/topics/distlock.md
+++ b/topics/distlock.md
@@ -26,6 +26,7 @@ already available that can be used for reference.
 * [Redlock-rb](https://github.com/antirez/redlock-rb) (Ruby implementation). There is also a [fork of Redlock-rb](https://github.com/leandromoreira/redlock-rb) that adds a gem for easy distribution and perhaps more.
 * [Redlock-py](https://github.com/SPSCommerce/redlock-py) (Python implementation).
 * [Redlock-php](https://github.com/ronnylt/redlock-php) (PHP implementation).
+* [PHPRedisMutex](https://github.com/malkusch/lock#phpredismutex) (further PHP implementation)
 * [Redsync.go](https://github.com/hjr265/redsync.go) (Go implementation).
 * [Redisson](https://github.com/mrniko/redisson) (Java implementation).
 * [Redis::DistLock](https://github.com/sbertrang/redis-distlock) (Perl implementation).


### PR DESCRIPTION
The current link to the PHP implementation has some limitations, i.e. there's no release, it doesn't support both Redis-APIs. So therefore I [implemented the Redlock algorithm](https://github.com/malkusch/lock#phpredismutex) as well and released it. I would be happy to see that reference in the documentation.

Also I'd like to use this opportunity to ask why the algorithm proposes to release also locks which weren't acquired.