### PR TITLE
fix lru-cache.md: allkeys-lru is not suitable for persistent situation

### DIFF
--- a/topics/lru-cache.md
+++ b/topics/lru-cache.md
@@ -63,7 +63,7 @@ In general as a rule of thumb:
 * Use the **allkeys-random** if you have a cyclic access where all the keys are scanned continuously, or when you expect the distribution to be uniform (all elements likely accessed with the same probability).
 * Use the **volatile-ttl** if you want to be able to provide hints to Redis about what are good candidate for expiration by using different TTL values when you create your cache objects.
 
-The **allkeys-lru** and **volatile-random** policies are mainly useful when you want to use a single instance for both caching and to have a set of persistent keys. However it is usually a better idea to run two Redis instances to solve such a problem.
+The **volatile-lru** and **volatile-random** policies are mainly useful when you want to use a single instance for both caching and to have a set of persistent keys. However it is usually a better idea to run two Redis instances to solve such a problem.
 
 It is also worth to note that setting an expire to a key costs memory, so using a policy like **allkeys-lru** is more memory efficient since there is no need to set an expire for the key to be evicted under memory pressure.
 


### PR DESCRIPTION
**allkeys-lru** is not suitable for both caching and to have a set of persistent keys in one instance. But **volatile-lru** is very suitable for the situation. 
 
This is just my point of view, please check it. Very thanks.