### PR TITLE
Add the Redix client

### DIFF
--- a/clients.json
+++ b/clients.json
@@ -1042,6 +1042,14 @@
     "repository": "https://github.com/mikeheier/Redis-AS3",
     "description": "An as3 client library for redis.",
     "authors": []
-  }
+  },
 
+  {
+    "name": "redix",
+    "language": "Elixir",
+    "repository": "https://github.com/whatyouhide/redix",
+    "description": "Superfast, pipelined, resilient Redis client written in pure Elixir.",
+    "authors": ["whatyouhide"],
+    "active": true
+  }
 ]


### PR DESCRIPTION
I added [Redix](https://github.com/whatyouhide/redix), a Redis client I developed in pure Elixir, to the list of clients in `clients.json`. Let me know if I can do anything else, thanks! :)