### PR TITLE
Add GEO's six commands into "redis-client for C++"

### DIFF
--- a/clients.json
+++ b/clients.json
@@ -805,7 +805,7 @@
     "language": "C++",
     "url": "https://github.com/zhengshuxin/acl/tree/master/lib_acl_cpp/samples/redis",
     "repository": "https://github.com/zhengshuxin/acl/tree/master/lib_acl_cpp/include/acl_cpp/redis",
-    "description": "full redis client commands, one redis command one redis function, including STRING, HASH, LIST, SET, ZSET, HLL, PUBSUB, TRANSACTION, SCRIPT, CONNECTION, SERVER, CLUSTER",
+    "description": "full redis client commands, one redis command one redis function, including STRING, HASH, LIST, SET, ZSET, HLL, PUBSUB, TRANSACTION, SCRIPT, CONNECTION, SERVER, CLUSTER, GEO",
     "authors": [],
     "active": true
   },


### PR DESCRIPTION
The "redis-client for C++" of acl has supported GEO's six commands including "geoadd, geohash, geopos, geodist, georadius, georadiusbymember" functions in class redis_geo.