### PR TITLE
PFMERGE includes target HLL in the merge

### DIFF
--- a/commands/pfmerge.md
+++ b/commands/pfmerge.md
@@ -5,6 +5,10 @@ structures.
 The computed merged HyperLogLog is set to the destination variable, which is
 created if does not exist (defaulting to an empty HyperLogLog).
 
+If the destination variable exists, it is treated as one of the source sets 
+and its cardinality will be included in the cardinality of the computed
+HyperLogLog.
+
 @return
 
 @simple-string-reply: The command just returns `OK`.


### PR DESCRIPTION
This surprised me and wasn't a documented behavior, but it is 100% reproducible. The docs state that the source sets are merged into a new HyperLogLog, which set to the destination key; they do not state that the destination key is party to the merge.

```
127.0.0.1:6379> PFADD test 1
(integer) 1
127.0.0.1:6379> PFADD test 2
(integer) 1
127.0.0.1:6379> PFADD test 3
(integer) 1
127.0.0.1:6379> PFCOUNT test
(integer) 3
127.0.0.1:6379> PFADD foo 1
(integer) 1
127.0.0.1:6379> PFADD foo 2
(integer) 1
127.0.0.1:6379> PFCOUNT foo
(integer) 2
127.0.0.1:6379> PFMERGE targ foo test
OK
127.0.0.1:6379> PFCOUNT targ
(integer) 3
127.0.0.1:6379> PFADD bar 6
(integer) 1
127.0.0.1:6379> PFMERGE targ foo bar
OK
127.0.0.1:6379> PFCOUNT targ
(integer) 4
```
