### PR TITLE
simplify dependency installation, esp. ruby gems

### DIFF
--- a/.gems
+++ b/.gems
@@ -1,2 +1,0 @@
-batch -v 1.0.4
-redcarpet -v 3.3.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,12 @@ addons:
     packages:
     - aspell
     - aspell-en
+    - par
 
 rvm:
    - 2.2
 
 install:
-  - gem install $(sed -e 's/ -v /:/' .gems)
+  - bundle install
 
 script: make -s

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gem 'batch', '1.0.4'
+gem 'redcarpet', '3.3.2'
+gem 'nokogiri'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,19 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    batch (1.0.4)
+    mini_portile (0.6.2)
+    nokogiri (1.6.6.2)
+      mini_portile (~> 0.6.0)
+    redcarpet (3.3.2)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  batch (= 1.0.4)
+  nokogiri
+  redcarpet (= 3.3.2)
+
+BUNDLED WITH
+   1.10.6

--- a/README.md
+++ b/README.md
@@ -81,24 +81,25 @@ The formatter has the following dependencies:
 
 * Redcarpet
 * Nokogiri
-* The `par` tool
+* par
+* aspell
 
 Installation of the Ruby gems:
 
 ```
-gem install redcarpet nokogiri
+bundle install
 ```
 
-Installation of par (OSX):
+Installation of par and aspell (OSX):
 
 ```
-brew install par
+brew install par aspell
 ```
 
 Installation of par (Ubuntu):
 
 ```
-sudo apt-get install par
+sudo apt-get install par aspell aspell-en
 ```
 
 ## Checking your work
@@ -112,14 +113,4 @@ $ make
 This will make sure that JSON and Markdown files compile and that all
 text files have no typos.
 
-You need to install a few Ruby gems and [Aspell][aspell] to run these checks.
-The gems are listed in the `.gems` file. Install them with the
-following command:
-
-```
-$ gem install $(sed -e 's/ -v /:/' .gems)
-```
-
 The spell checking exceptions should be added to `./wordlist`.
-
-[aspell]: http://aspell.net/


### PR DESCRIPTION
using a `.gems` file is antiquated, use industry-standard `bundler` instead

also clarify `apt-get` and `brew` usage