### PR TITLE
add cpp_redis to clients.json

### DIFF
--- a/clients.json
+++ b/clients.json
@@ -1276,5 +1276,14 @@
     "description": "Redis C++ client with data slice storage and connection pool support, requires hiredis only",
     "authors": ["0xsky"],
     "active": true
+  },
+
+  {
+    "name": "cpp_redis",
+    "language": "C++",
+    "repository": "https://github.com/cylix/cpp_redis",
+    "description": "Modern C++11 Redis client based on boost::asio",
+    "authors": ["simon_ninon"],
+    "active": true
   }
 ]


### PR DESCRIPTION
Hi,

I've developed a C++11 redis client based on boost::asio.
Library is tested and documented (more documentation is coming).

I've added references to this library in the clients.json file.
