### PR TITLE
Add Hedis support

### DIFF
--- a/tools.json
+++ b/tools.json
@@ -532,5 +532,13 @@
     "repository": "https://github.com/maxbrieiev/promise-redis",
     "description": "Use any promise library with node_redis.",
     "authors": []
+  },
+  {
+    "name": "Hedis",
+    "language": "C",
+    "url": "http://hedis.io/",
+    "repository": "https://github.com/hedisdb/hedis",
+    "description": "Hedis can retrieve data from **ANY** database directly via Redis",
+    "authors": ["kewang"]
   }
 ]


### PR DESCRIPTION
## Hedis can retrieve data from **ANY** database directly via Redis.

[Hedis Website](http://hedis.io/)

![](https://cloud.githubusercontent.com/assets/795839/8285334/3d6ee5e8-1935-11e5-809e-59bf9afbbe92.png)

Traditionally, application server retrieves hot data from in-memory database (like Redis) to reduce unnecessary paths. If in-memory database doesn't have specific data, application server gets back to retrieve data from original database.

![](https://cloud.githubusercontent.com/assets/795839/8285335/3d967ce8-1935-11e5-8b3b-0194d90b9e4d.png)

Hedis can retrieve data from ANY database directly via Redis. Application server retrieves hot data from Hedis server, If Hedis server doesn't have specific data, Hedis retrieves data from original database via ANY connector.