### PR TITLE
Remove Aleph from client implementation list

### DIFF
--- a/clients.json
+++ b/clients.json
@@ -19,14 +19,6 @@
     "active": true
   },
   {
-    "name": "aleph",
-    "language": "Clojure",
-    "repository": "https://github.com/ztellman/aleph",
-    "description": "Redis client build on top of lamina",
-    "authors": ["ztellman"],
-    "active": true
-  },
-  {
     "name": "CL-Redis",
     "language": "Common Lisp",
     "url": "http://www.cliki.net/cl-redis",


### PR DESCRIPTION
As of the latest release, it only provides TCP, HTTP, and UDP protocol implementations.