### PR TITLE
Corrects a typo

### DIFF
--- a/commands.json
+++ b/commands.json
@@ -417,7 +417,7 @@
     "group": "cluster"
   },
   "CLUSTER SETSLOT": {
-    "summary": "Bind an hash slot to a specific node",
+    "summary": "Bind a hash slot to a specific node",
     "complexity": "O(1)",
     "arguments": [
       {

--- a/commands/cluster-nodes.md
+++ b/commands/cluster-nodes.md
@@ -45,7 +45,7 @@ The meaning of each filed is the following:
 6. `pong-recv`: Milliseconds unix time the last pong was received.
 7. `config-epoch`: The configuration epoch (or version) of the current node (or of the current master if the node is a slave). Each time there is a failover, a new, unique, monotonically increasing configuration epoch is created. If multiple nodes claim to serve the same hash slots, the one with higher configuration epoch wins.
 8. `link-state`: The state of the link used for the node-to-node cluster bus. We use this link to communicate with the node. Can be `connected` or `disconnected`.
-9. `slot`: An hash slot number or range. Starting from argument number 9, but there may be up to 16384 entries in total (limit never reached). This is the list of hash slots served by this node. If the entry is just a number, is parsed as such. If it is a range, it is in the form `start-end`, and means that the node is responsible for all the hash slots from `start` to `end` including the start and end values.
+9. `slot`: A hash slot number or range. Starting from argument number 9, but there may be up to 16384 entries in total (limit never reached). This is the list of hash slots served by this node. If the entry is just a number, is parsed as such. If it is a range, it is in the form `start-end`, and means that the node is responsible for all the hash slots from `start` to `end` including the start and end values.
 
 Meaning of the flags (field number 3):
 

--- a/commands/cluster-setslot.md
+++ b/commands/cluster-setslot.md
@@ -1,11 +1,11 @@
-`CLUSTER SETSLOT` is responsible of changing the state of an hash slot in the receiving node in different ways. It can, depending on the subcommand used:
+`CLUSTER SETSLOT` is responsible of changing the state of a hash slot in the receiving node in different ways. It can, depending on the subcommand used:
 
 1. `MIGRATING` subcommand: Set a hash slot in *migrating* state.
 2. `IMPORTING` subcommand: Set a hash slot in *importing* state.
 3. `STABLE` subcommand: Clear any importing / migrating state from hash slot.
 4. `NODE` subcommand: Bind the hash slot to a different node.
 
-The command with its set of subcommands is useful in order to start and end cluster live resharding operations, which are accomplished by setting an hash slot in migrating state in the source node, and importing state in the destination node.
+The command with its set of subcommands is useful in order to start and end cluster live resharding operations, which are accomplished by setting a hash slot in migrating state in the source node, and importing state in the destination node.
 
 Each subcommand is documented below. At the end you'll find a description of
 how live resharding is performed using this command and other related commands.
@@ -35,7 +35,7 @@ When a slot is set in importing state, the node changes behavior in the followin
 
 In this way when a node in migrating state generates an `ASK` redirection, the client contacts the target node, sends `ASKING`, and immediately after sends the command. This way commands about non-existing keys in the old node or keys already migrated to the target node are executed in the target node, so that:
 
-1. New keys are always created in the target node. During an hash slot migration we'll have to move only old keys, not new ones.
+1. New keys are always created in the target node. During a hash slot migration we'll have to move only old keys, not new ones.
 2. Commands about keys already migrated are correctly processed in the context of the node which is the target of the migration, the new hash slot owner, in order to guarantee consistency.
 3. Without `ASKING` the behavior is the same as usually. This guarantees that clients with a broken hash slots mapping will not write for error in the target node, creating a new version of a key that has yet to be migrated.
 
@@ -56,7 +56,7 @@ command:
 
 1. If the current hash slot owner is the node receiving the command, but for effect of the command the slot would be assigned to a different node, the command will return an error if there are still keys for that hash slot in the node receiving the command.
 2. If the slot is in *migrating* state, the state gets cleared when the slot is assigned to another node.
-3. If the slot was in *importing* state in the node receiving the command, and the command assigns the slot to this node (which happens in the target node at the end of the resharding of an hash slot from one node to another), the command has the following side effects: A) the *importing* state is cleared. B) If the node config epoch is not already the greatest of the cluster, it generates a new one and assigns the new config epoch to itself. This way its new hash slot ownership will win over any past configuration created by previous failovers or slot migrations.
+3. If the slot was in *importing* state in the node receiving the command, and the command assigns the slot to this node (which happens in the target node at the end of the resharding of a hash slot from one node to another), the command has the following side effects: A) the *importing* state is cleared. B) If the node config epoch is not already the greatest of the cluster, it generates a new one and assigns the new config epoch to itself. This way its new hash slot ownership will win over any past configuration created by previous failovers or slot migrations.
 
 It is important to note that step 3 is the only time when a Redis Cluster node will create a new config epoch without agreement from other nodes. This only happens when a manual configuration is operated. However it is impossible that this creates a non-transient setup where two nodes have the same config epoch, since Redis Cluster uses a config epoch collision resolution algorithm.
 

--- a/commands/hincrbyfloat.md
+++ b/commands/hincrbyfloat.md
@@ -1,4 +1,4 @@
-Increment the specified `field` of an hash stored at `key`, and representing a
+Increment the specified `field` of a hash stored at `key`, and representing a
 floating point number, by the specified `increment`.
 If the field does not exist, it is set to `0` before performing the operation.
 An error is returned if one of the following conditions occur:

--- a/commands/scan.md
+++ b/commands/scan.md
@@ -75,7 +75,7 @@ However there is a way for the user to tune the order of magnitude of the number
 While `SCAN` does not provide guarantees about the number of elements returned at every iteration, it is possible to empirically adjust the behavior of `SCAN` using the **COUNT** option. Basically with COUNT the user specified the *amount of work that should be done at every call in order to retrieve elements from the collection*. This is **just an hint** for the implementation, however generally speaking this is what you could expect most of the times from the implementation.
 
 * The default COUNT value is 10.
-* When iterating the key space, or a Set, Hash or Sorted Set that is big enough to be represented by an hash table, assuming no **MATCH** option is used, the server will usually return *count* or a bit more than *count* elements per call.
+* When iterating the key space, or a Set, Hash or Sorted Set that is big enough to be represented by a hash table, assuming no **MATCH** option is used, the server will usually return *count* or a bit more than *count* elements per call.
 * When iterating Sets encoded as intsets (small sets composed of just integers), or Hashes and Sorted Sets encoded as ziplists (small hashes and sets composed of small individual values), usually all the elements are returned in the first `SCAN` call regardless of the COUNT value.
 
 Important: **there is no need to use the same COUNT value** for every iteration. The caller is free to change the count from one iteration to the other as required, as long as the cursor passed in the next call is the one obtained in the previous call to the command.
@@ -173,7 +173,7 @@ This is easy to see intuitively: if the collection grows there is more and more 
 
 ## Additional examples
 
-Iteration of an Hash value.
+Iteration of a Hash value.
 
 ```
 redis 127.0.0.1:6379> hmset hash name Jack age 33

--- a/topics/pubsub.md
+++ b/topics/pubsub.md
@@ -178,7 +178,7 @@ Because all the messages received contain the original subscription
 causing the message delivery (the channel in the case of message type,
 and the original pattern in the case of pmessage type) client libraries
 may bind the original subscription to callbacks (that can be anonymous
-functions, blocks, function pointers), using an hash table.
+functions, blocks, function pointers), using a hash table.
 
 When a message is received an O(1) lookup can be done in order to
 deliver the message to the registered callback.

--- a/topics/security.md
+++ b/topics/security.md
@@ -121,7 +121,7 @@ the ability to insert data into Redis that triggers pathological (worst case)
 algorithm complexity on data structures implemented inside Redis internals.
 
 For instance an attacker could supply, via a web form, a set of strings that
-is known to hash to the same bucket into an hash table in order to turn the
+is known to hash to the same bucket into a hash table in order to turn the
 O(1) expected time (the average time) to the O(N) worst case, consuming more
 CPU than expected, and ultimately causing a Denial of Service.
 

--- a/topics/twitter-clone.md
+++ b/topics/twitter-clone.md
@@ -158,7 +158,7 @@ collection of fields associated with values:
 
 `HMSET` can be used to set fields in the hash, that can be retrieved with
 `HGET` later. It is possible to check if a field exists with `HEXISTS`, or
-to increment an hash field with `HINCRBY` and so forth.
+to increment a hash field with `HINCRBY` and so forth.
 
 Hashes are the ideal data structure to represent *objects*. For example we
 use Hashes in order to represent Users and Updates in our Twitter clone.
@@ -183,11 +183,11 @@ Let's start with Users. We need to represent users, of course, with their userna
     INCR next_user_id => 1000
     HMSET user:1000 username antirez password p1pp0
 
-*Note: you should use an hashed password in a real application, for simplicity
+*Note: you should use a hashed password in a real application, for simplicity
 we store the password in clear text.*
 
-We use the `next_user_id` key in order to always get an unique ID for every new user. Then we use this unique ID to name the key holding an Hash with user's data. *This is a common design pattern* with key-values stores! Keep it in mind.
-Besides the fields already defined, we need some more stuff in order to fully define a User. For example, sometimes it can be useful to be able to get the user ID from the username, so every time we add an user, we also populate the `users` key, which is an Hash, with the username as field, and its ID as value.
+We use the `next_user_id` key in order to always get an unique ID for every new user. Then we use this unique ID to name the key holding a Hash with user's data. *This is a common design pattern* with key-values stores! Keep it in mind.
+Besides the fields already defined, we need some more stuff in order to fully define a User. For example, sometimes it can be useful to be able to get the user ID from the username, so every time we add an user, we also populate the `users` key, which is a Hash, with the username as field, and its ID as value.
 
     HSET users antirez 1000
 
@@ -235,7 +235,7 @@ an `auth` field in its Hash:
     HSET user:1000 auth fea5e81ac8ca77622bed1c2132a021f9
 
 Moreover, we need a way to map authentication secrets to user IDs, so
-we also take an `auths` key, which has as value an Hash type mapping
+we also take an `auths` key, which has as value a Hash type mapping
 authentication secrets to user IDs.
 
     HSET auths fea5e81ac8ca77622bed1c2132a021f9 1000
@@ -339,7 +339,7 @@ Updates, also known as posts, are even simpler. In order to create a new post in
     INCR next_post_id => 10343
     HMSET post:10343 user_id $owner_id time $time body "I'm having fun with Retwis"
 
-As you can see each post is just represented by an Hash with three fields. The ID of the user owning the post, the time at which the post was published, and finally the body of the post, which is, the actual status message.
+As you can see each post is just represented by a Hash with three fields. The ID of the user owning the post, the time at which the post was published, and finally the body of the post, which is, the actual status message.
 
 After we create a post and we obtain the post ID, we need to LPUSH the ID in the timeline of every user that is following the author of the post, and of course in the list of posts of the author itself (everybody is virtually following herself/himself). This is the file `post.php` that shows how this is performed:
 


### PR DESCRIPTION
Replaces instances of "an hash" with "a hash".