### PR TITLE
Change Swift-Redis client name to ZRedis

### DIFF
--- a/clients.json
+++ b/clients.json
@@ -1239,9 +1239,9 @@
   },
 
  {
-    "name": "Swift-Redis",
+    "name": "ZRedis",
     "language": "Swift",
-    "repository": "https://github.com/rabc/Swift-Redis",
+    "repository": "https://github.com/rabc/ZRedis",
     "description": "Redis client for (pure) Swift",
     "authors": ["rabc"],
     "active": true


### PR DESCRIPTION
I had to change the library name due to Swift name conventions.