### PR TITLE
Expire only returns 0 if the key doesn't exist.

### DIFF
--- a/commands/expire.md
+++ b/commands/expire.md
@@ -38,12 +38,14 @@ command altering its value had the effect of removing the key entirely.
 This semantics was needed because of limitations in the replication layer that
 are now fixed.
 
+`EXPIRE` would return 0 and not alter the timeout for a key with a timeout set.
+
 @return
 
 @integer-reply, specifically:
 
 * `1` if the timeout was set.
-* `0` if `key` does not exist or the timeout could not be set.
+* `0` if `key` does not exist.
 
 @examples
 

--- a/commands/expireat.md
+++ b/commands/expireat.md
@@ -19,7 +19,7 @@ a given time in the future.
 @integer-reply, specifically:
 
 * `1` if the timeout was set.
-* `0` if `key` does not exist or the timeout could not be set (see: `EXPIRE`).
+* `0` if `key` does not exist.
 
 @examples
 

--- a/commands/pexpire.md
+++ b/commands/pexpire.md
@@ -6,7 +6,7 @@ specified in milliseconds instead of seconds.
 @integer-reply, specifically:
 
 * `1` if the timeout was set.
-* `0` if `key` does not exist or the timeout could not be set.
+* `0` if `key` does not exist.
 
 @examples
 

--- a/commands/pexpireat.md
+++ b/commands/pexpireat.md
@@ -6,7 +6,7 @@ which the key will expire is specified in milliseconds instead of seconds.
 @integer-reply, specifically:
 
 * `1` if the timeout was set.
-* `0` if `key` does not exist or the timeout could not be set (see: `EXPIRE`).
+* `0` if `key` does not exist.
 
 @examples
 


### PR DESCRIPTION
## Problem

The documentation wasn't clear about why a timeout might not be set for expiry commands, so I had to dig into the source code to find the answer.
## Research

In the [latest version of the EXPIRE source code](https://github.com/antirez/redis/blob/3.0.7/src/db.c#L875-L923) it only returns 0 if the key doesn't exist.

Before 2.2.0, commit https://github.com/antirez/redis/commit/0cf5b7b57cde8b699198a866b04feca9f5394d03 removed the possibility of expire returning 0 because expire couldn't be set.  Before that commit, the expiry couldn't be set for a key that already had its expiry set.  
## Description of Change

I clarified the reason for EXPIRE returning 0 to mention that it happened when the timeout was already set under the [EXPIRE section on redis prior to 2.1.3](http://redis.io/commands/expire#differences-in-redis-prior-213), then removed the mention of this case from the return value documentation for the expiry commands.
