### PR TITLE
adds redis-bash to clients.json

### DIFF
--- a/clients.json
+++ b/clients.json
@@ -1168,6 +1168,15 @@
   },
 
   {
+    "name": "redis-bash",
+    "language": "Bash",
+    "repository": "https://github.com/caquino/redis-bash",
+    "description": "Pure bash redis client implementation",
+    "authors": ["caquino"],
+    "active": true
+  },
+
+  {
     "name": "amphp/redis",
     "language": "PHP",
     "repository": "https://github.com/amphp/redis",
@@ -1354,7 +1363,7 @@
     "authors": ["danieleteti"],
     "active": true
   },
-  
+
   {
     "name": "eredis",
     "language": "C",
@@ -1371,7 +1380,7 @@
     "description": "High-performance Erlang client for the Redis key-value store (NIF wrapping the hiredis C client).",
     "authors": ["funbox_team"]
   },
-  
+
   {
     "name": "yoredis",
     "language": "Node.js",

--- a/wordlist
+++ b/wordlist
@@ -144,6 +144,7 @@ addr
 afterwards
 allkeys
 allocator
+analytics
 antirez
 aof
 appendfsync
@@ -156,6 +157,7 @@ backtrace
 benchmarked
 benchmarking
 bgsave
+bitfield
 bitop
 bitwise
 blazingly
@@ -171,6 +173,7 @@ checksum
 chrt
 cli
 cmsgpack
+codename
 commandstats
 conf
 config
@@ -360,6 +363,7 @@ tuple
 tuples
 unary
 unencrypted
+underflows
 unguessable
 unix
 unordered


### PR DESCRIPTION
This PR adds redis-bash to the clients.json list as documented at http://redis.io/clients.
Thanks
