### PR TITLE
Add Java rdb-parser tool

### DIFF
--- a/tools.json
+++ b/tools.json
@@ -574,7 +574,6 @@
     "name": "rdb-parser",
     "language": "Java",
     "repository": "https://github.com/jwhitbeck/java-rdb-parser",
-    "description": "A simple Redis RDB file parser for Java",
-    "authors": ["jwhitbeck"]
+    "description": "A simple Redis RDB file parser for Java"
   }
 ]

--- a/tools.json
+++ b/tools.json
@@ -569,5 +569,12 @@
     "repository": "https://github.com/leegould/RedisExplorer",
     "description": "Windows desktop GUI client",
     "authors": ["leegould"]
+  },
+  {
+    "name": "rdb-parser",
+    "language": "Java",
+    "repository": "https://github.com/jwhitbeck/java-rdb-parser",
+    "description": "A simple Redis RDB file parser for Java",
+    "authors": ["jwhitbeck"]
   }
 ]


### PR DESCRIPTION
We've been successfully using this library in production for 6 months and would like to share with the community. I just added support for parsing RDB version 7.