### PR TITLE
add r3c, a Redis Cluster C++ Client

### DIFF
--- a/clients.json
+++ b/clients.json
@@ -1395,7 +1395,7 @@
     "language": "C++",
     "repository": "https://github.com/eyjian/r3c",
     "description": "A Redis Cluster C++ Client, based on hiredis and support standalone, it's easy to make and use, not depends on C++11 or later.",
-    "authors": ["JianYi"],
+    "authors": [],
     "active": true
   }
 

--- a/clients.json
+++ b/clients.json
@@ -1395,7 +1395,7 @@
     "language": "C++",
     "repository": "https://github.com/eyjian/r3c",
     "description": "A Redis Cluster C++ Client, based on hiredis and support standalone, it's easy to make and use, not depends on C++11 or later.",
-    "authors": ["JianYi"],
+    "authors": ["eyjian"],
     "active": true
   }
 

--- a/clients.json
+++ b/clients.json
@@ -1388,6 +1388,15 @@
     "description": "A connector between Apache Spark and Redis.",
     "authors": ["redislabs", "sunheehnus", "dvirsky"],
     "active": true
+  },
+
+  {
+    "name": "r3c",
+    "language": "C++",
+    "repository": "https://github.com/eyjian/r3c",
+    "description": "A Redis Cluster C++ Client, based on hiredis and support standalone, it's easy to make and use, not depends on C++11 or later.",
+    "authors": ["JianYi"],
+    "active": true
   }
 
 ]

--- a/clients.json
+++ b/clients.json
@@ -1395,7 +1395,7 @@
     "language": "C++",
     "repository": "https://github.com/eyjian/r3c",
     "description": "A Redis Cluster C++ Client, based on hiredis and support standalone, it's easy to make and use, not depends on C++11 or later.",
-    "authors": [],
+    "authors": ["JianYi"],
     "active": true
   }
 


### PR DESCRIPTION
r3c is a Redis Cluster C++ Client, based on hiredis and support standalone, it's easy to make and use, not depends on C++11 or later.