### PR TITLE
Updated Nim client info

### DIFF
--- a/clients.json
+++ b/clients.json
@@ -957,8 +957,7 @@
   {
     "name": "redis",
     "language": "Nim",
-    "repository": "https://github.com/nim-lang/Nim/blob/devel/lib/pure/redis.nim",
-    "url": "http://nim-lang.org/docs/redis.html",
+    "repository": "https://github.com/nim-lang/redis",
     "description": "Redis client for Nim",
     "authors": [],
     "active": true


### PR DESCRIPTION
It moved out of the standard library, thus there's no more docs on the official website.