### PR TITLE
Fix typo in PFCOUNT time complexity description

### DIFF
--- a/commands.json
+++ b/commands.json
@@ -1712,7 +1712,7 @@
   },
   "PFCOUNT": {
     "summary": "Return the approximated cardinality of the set(s) observed by the HyperLogLog at key(s).",
-    "complexity": "O(1) with every small average constant times when called with a single key. O(N) with N being the number of keys, and much bigger constant times, when called with multiple keys.",
+    "complexity": "O(1) with a very small average constant time when called with a single key. O(N) with N being the number of keys, and much bigger constant times, when called with multiple keys.",
     "arguments": [
       {
         "name": "key",


### PR DESCRIPTION
I don't quite understand the original phrasing but think this fixes a typo and hope that it correctly describes the behavior of `PFCOUNT`.