### PR TITLE
Perl client AnyEvent::Redis::RipeRedis renamed to AnyEvent::RipeRedis. Added Perl client AnyEvent::RipeRedis::Cluster

### DIFF
--- a/clients.json
+++ b/clients.json
@@ -343,6 +343,17 @@
   },
 
   {
+    "name": "AnyEvent::RipeRedis::Cluster",
+    "language": "Perl",
+    "url": "http://search.cpan.org/dist/AnyEvent-RipeRedis-Cluster/",
+    "repository": "https://github.com/iph0/AnyEvent-RipeRedis-Cluster",
+    "description": "Non-blocking Redis Cluster client",
+    "authors": ["iph0"],
+    "recommended": false,
+    "active": true
+  },
+
+  {
     "name": "AnyEvent::Hiredis",
     "language": "Perl",
     "url": "http://search.cpan.org/dist/AnyEvent-Hiredis/",

--- a/clients.json
+++ b/clients.json
@@ -337,7 +337,7 @@
     "url": "http://search.cpan.org/dist/AnyEvent-RipeRedis/",
     "repository": "https://github.com/iph0/AnyEvent-RipeRedis",
     "description": "Flexible non-blocking Redis client",
-    "authors": ["iph"],
+    "authors": ["iph0"],
     "recommended": true,
     "active": true
   },

--- a/clients.json
+++ b/clients.json
@@ -332,12 +332,13 @@
   },
 
   {
-    "name": "AnyEvent::Redis::RipeRedis",
+    "name": "AnyEvent::RipeRedis",
     "language": "Perl",
-    "url": "http://search.cpan.org/dist/AnyEvent-Redis-RipeRedis/",
-    "repository": "https://github.com/iph0/AnyEvent-Redis-RipeRedis",
-    "description": "Flexible non-blocking Redis client with reconnect feature",
+    "url": "http://search.cpan.org/dist/AnyEvent-RipeRedis/",
+    "repository": "https://github.com/iph0/AnyEvent-RipeRedis",
+    "description": "Flexible non-blocking Redis client",
     "authors": ["iph"],
+    "recommended": true,
     "active": true
   },
 


### PR DESCRIPTION
AnyEvent::RipeRedis is the new incarnation of AnyEvent::Redis::RipeRedis.
AnyEvent::Redis::RipeRedis will no longer be supported and must not
be used in new code.

Also added Perl client AnyEvent::RipeRedis::Cluster
