### PR TITLE
Change 'think at' phrases to proper ones

### DIFF
--- a/commands/expire.md
+++ b/commands/expire.md
@@ -60,8 +60,8 @@ TTL mykey
 Imagine you have a web service and you are interested in the latest N pages
 _recently_ visited by your users, such that each adjacent page view was not
 performed more than 60 seconds after the previous.
-Conceptually you may think at this set of page views as a _Navigation session_
-if your user, that may contain interesting information about what kind of
+Conceptually you may consider this set of page views as a _Navigation session_
+of your user, that may contain interesting information about what kind of
 products he or she is looking for currently, so that you can recommend related
 products.
 

--- a/commands/shutdown.md
+++ b/commands/shutdown.md
@@ -25,7 +25,7 @@ Specifically:
   configured.
 * **SHUTDOWN NOSAVE** will prevent a DB saving operation even if one or more
   save points are configured.
-  (You can think at this variant as an hypothetical **ABORT** command that just
+  (You can think of this variant as an hypothetical **ABORT** command that just
   stops the server).
 
 @return

--- a/topics/internals-vm.md
+++ b/topics/internals-vm.md
@@ -242,7 +242,7 @@ This is what we do:
  * If we detect that at least a key in the requested command is swapped on disk, we block the client instead of really issuing the command. For every swapped value associated to a requested key, an I/O job is created, in order to bring the values back in memory. The main thread continues the execution of the event loop, without caring about the blocked client.
  * In the meanwhile, I/O threads are loading values in memory. Every time an I/O thread finished loading a value, it sends a byte to the main thread using an UNIX pipe. The pipe file descriptor has a readable event associated in the main thread event loop, that is the function `vmThreadedIOCompletedJob`. If this function detects that all the values needed for a blocked client were loaded, the client is restarted and the original command called.
 
-So you can think at this as a blocked VM that almost always happen to have the right keys in memory, since we pause clients that are going to issue commands about swapped out values until this values are loaded.
+So you can think of this as a blocked VM that almost always happen to have the right keys in memory, since we pause clients that are going to issue commands about swapped out values until this values are loaded.
 
 If the function checking what argument is a key fails in some way, there is no problem: the lookup function will see that a given key is associated to a swapped out value and will block loading it. So our non blocking VM reverts to a blocking one when it is not possible to anticipate what keys are touched.
 

--- a/topics/replication.md
+++ b/topics/replication.md
@@ -180,7 +180,9 @@ This is how the feature works:
 
 If there are at least N slaves, with a lag less than M seconds, then the write will be accepted.
 
-You may think at it as a relaxed version of the "C" in the CAP theorem, where consistency is not ensured for a given write, but at least the time window for data loss is restricted to a given number of seconds.
+You may think of it as a relaxed version of the "C" in the CAP theorem, where
+consistency is not ensured for a given write, but at least the time window for
+data loss is restricted to a given number of seconds.
 
 If the conditions are not met, the master will instead reply with an error and the write will not be accepted.
 


### PR DESCRIPTION
In English language there is no 'think at' phrase. Also fixed a typo.