### PR TITLE
I think this is what it is suppossed to be.

### DIFF
--- a/topics/cluster-tutorial.md
+++ b/topics/cluster-tutorial.md
@@ -652,7 +652,7 @@ This is what happens, for example, if I reset a counter manually while
 the program is running:
 
 ```
-$ redis 127.0.0.1:7000> set key_217 0
+$ redis-cli -h 127.0.0.1 -p 7000 set key_217 0
 OK
 
 (in the other tab I see...)


### PR DESCRIPTION
I think this is correct, although I can't get the `consistency-test.rb` script to output what it lost.