### PR TITLE
add 'redis-migrate-tool' for redis tools

### DIFF
--- a/tools.json
+++ b/tools.json
@@ -583,5 +583,12 @@
     "repository": "https://github.com/cheprasov/php-redis-lock",
     "description": "RedisLock for PHP is a synchronization mechanism for enforcing limits on access to a resource in an environment where there are many threads of execution. A lock is designed to enforce a mutual exclusion concurrency control policy.",
     "authors": ["cheprasov84"]
+  },
+  {
+    "name": "redis-migrate-tool",
+    "language": "C",
+    "repository": "https://github.com/vipshop/redis-migrate-tool",
+    "description": "A convenient and useful tool for migrating data between redis groups.",
+    "authors": ["diguo58"]
   }
 ]


### PR DESCRIPTION
As the title.
We and some other companies used this tool in the production for redis migration.