### PR TITLE
fix typo in commands/srandmember.md

### DIFF
--- a/commands/srandmember.md
+++ b/commands/srandmember.md
@@ -34,6 +34,6 @@ When instead the count is negative, the behavior changes and the extraction happ
 
 The distribution of the returned elements is far from perfect when the number of elements in the set is small, this is due to the fact that we used an approximated random element function that does not really guarantees good distribution.
 
-The algorithm used, that is implemented inside dict.c, samples the hash table buckets to find a non-empty one. Once a non empty bucket is found, since we use chaining in our hash table implementation, the number of elements inside the bucked is checked and a random element is selected.
+The algorithm used, that is implemented inside dict.c, samples the hash table buckets to find a non-empty one. Once a non empty bucket is found, since we use chaining in our hash table implementation, the number of elements inside the bucket is checked and a random element is selected.
 
 This means that if you have two non-empty buckets in the entire hash table, and one has three elements while one has just one, the element that is alone in its bucket will be returned with much higher probability.


### PR DESCRIPTION
The word `bucked` should be `bucket`.