### PR TITLE
Mention EXPIRE behavior with non-positive timeouts

### DIFF
--- a/commands/expire.md
+++ b/commands/expire.md
@@ -23,6 +23,14 @@ that is overwritten by a call like `RENAME Key_B Key_A`, it does not matter if
 the original `Key_A` had a timeout associated or not, the new key `Key_A` will
 inherit all the characteristics of `Key_B`.
 
+Note that calling `EXPIRE`/`PEXPIRE` with a non-positive timeout or
+`EXPIREAT`/`PEXPIREAT` with a time in the past will result in the key being
+[deleted][del] rather than expired (accordingly, the emitted [key event][ntf]
+will be `del`, not `expired`).
+
+[del]: /commands/del
+[ntf]: /topics/notifications
+
 ## Refreshing expires
 
 It is possible to call `EXPIRE` using as argument a key that already has an

--- a/commands/expireat.md
+++ b/commands/expireat.md
@@ -1,6 +1,7 @@
 `EXPIREAT` has the same effect and semantic as `EXPIRE`, but instead of
 specifying the number of seconds representing the TTL (time to live), it takes
-an absolute [Unix timestamp][hewowu] (seconds since January 1, 1970).
+an absolute [Unix timestamp][hewowu] (seconds since January 1, 1970). A
+timestamp in the past will delete the key immediately.
 
 [hewowu]: http://en.wikipedia.org/wiki/Unix_time
 

--- a/topics/notifications.md
+++ b/topics/notifications.md
@@ -96,7 +96,7 @@ Different commands generate different kind of events according to the following 
 
 * `DEL` generates a `del` event for every deleted key.
 * `RENAME` generates two events, a `rename_from` event for the source key, and a `rename_to` event for the destination key.
-* `EXPIRE` generates an `expire` event when an expire is set to the key, or a `expired` event every time setting an expire results into the key being deleted (see `EXPIRE` documentation for more info).
+* `EXPIRE` generates an `expire` event when an expire is set to the key, or an `expired` event every time a positive timeout set on a key results into the key being deleted (see `EXPIRE` documentation for more info).
 * `SORT` generates a `sortstore` event when `STORE` is used to set a new key. If the resulting list is empty, and the `STORE` option is used, and there was already an existing key with that name, the result is that the key is deleted, so a `del` event is generated in this condition.
 * `SET` and all its variants (`SETEX`, `SETNX`,`GETSET`) generate `set` events. However `SETEX` will also generate an `expire` events.
 * `MSET` generates a separated `set` event for every key.


### PR DESCRIPTION
The current documentation for EXPIRE does not mention that specifying a timeout less than or equal to zero does actually perform a DEL. This PR fixes this issue.

Also see http://stackoverflow.com/q/40636291/2516943

English is not my native language, so feel free to rephrase.