### PR TITLE
Fix grammar

### DIFF
--- a/topics/introduction.md
+++ b/topics/introduction.md
@@ -1,7 +1,7 @@
 Introduction to Redis
 ===
 
-Redis is an open source (BSD licensed), in-memory **data structure store**, used as database, cache and message broker. It supports data structures such as
+Redis is an open source (BSD licensed), in-memory **data structure store**, used as a database, cache and message broker. It supports data structures such as
 [strings](/topics/data-types-intro#strings), [hashes](/topics/data-types-intro#hashes), [lists](/topics/data-types-intro#lists), [sets](/topics/data-types-intro#sets), [sorted sets](/topics/data-types-intro#sorted-sets) with range queries, [bitmaps](/topics/data-types-intro#bitmaps), [hyperloglogs](/topics/data-types-intro#hyperloglogs) and [geospatial indexes](/commands/geoadd) with radius queries. Redis has built-in [replication](/topics/replication), [Lua scripting](/commands/eval), [LRU eviction](/topics/lru-cache), [transactions](/topics/transactions) and different levels of [on-disk persistence](/topics/persistence), and provides high availability via [Redis Sentinel](/topics/sentinel) and automatic partitioning with [Redis Cluster](/topics/cluster-tutorial).
 
 You can run **atomic operations**


### PR DESCRIPTION
This sounds much better with an 'a' between "used as" and "database". Fixes
the grammar, which I noticed whilst reading redis.io.