### PR TITLE
Updated link to scredis repo

### DIFF
--- a/clients.json
+++ b/clients.json
@@ -570,7 +570,7 @@
   {
     "name": "scredis",
     "language": "Scala",
-    "repository": "https://github.com/Livestream/scredis",
+    "repository": "https://github.com/scredis/scredis",
     "description": "Non-blocking, ultra-fast Scala Redis client built on top of Akka IO, used in production at Livestream",
     "authors": ["livestream"],
     "active": true


### PR DESCRIPTION
The https://github.com/Livestream/scredis is apparently no longer maintained, but links to a new repository: https://github.com/scredis/scredis.  