### PR TITLE
Add detail about `sentinel auth-pass` directive

### DIFF
--- a/topics/sentinel.md
+++ b/topics/sentinel.md
@@ -777,6 +777,12 @@ configuring in this slave only the `masterauth` directive, without
 using the `requirepass` directive, so that data will be readable by
 unauthenticated clients.
 
+In order for sentinels to connect to Redis server instances when they are
+configured with `requirepass`, the Sentinel configuration must include the
+`sentinel auth-pass` directive, in the format:
+
+    sentinel auth-pass <master-group-name> <pass>
+
 Sentinel clients implementation
 ---
 


### PR DESCRIPTION
Should explain in the "Sentinel and Redis authentication" how to set up
Sentinels so that they can connect to Redis servers that use
authentication.

/cc @badboy