### PR TITLE
Sort returns different replies depending on command arguments.

### DIFF
--- a/commands/sort.md
+++ b/commands/sort.md
@@ -137,4 +137,5 @@ key is accessed to retrieve the specified hash field.
 
 @return
 
-@array-reply: list of sorted elements.
+@array-reply: without passing the `store` option the command returns a list of sorted elements.
+@integer-reply: when the `store` option is specified the command returns the number of sorted elements in the destination list.


### PR DESCRIPTION
Small change to SORT documentation reply type specifying that it can either be an array or integer.