### PR TITLE
Add an MIT licensed RESP parser and Redis client

### DIFF
--- a/clients.json
+++ b/clients.json
@@ -1432,7 +1432,7 @@
     "name": "r3c",
     "language": "C++",
     "repository": "https://github.com/eyjian/r3c",
-    "description": "A Redis Cluster C++ Client, based on hiredis and support standalone, it's easy to make and use, not depends on C++11 or later.",
+    "description": "Redis Cluster C++ Client, based on hiredis, support password and standalone, it's easy to make and use, not depends on C++11 or later.",
     "authors": ["eyjian"],
     "active": true
   },

--- a/clients.json
+++ b/clients.json
@@ -490,7 +490,7 @@
     "description": "Async minimal redis client for tornado ioloop designed for performances (use C hiredis parser)",
     "active": true
   },
-  
+
   {
     "name": "brukva",
     "language": "Python",
@@ -1276,7 +1276,7 @@
     "authors": ["esilverberg"],
     "active": true
   },
-  
+
   {
     "name": "Rackdis",
     "language": "Racket",
@@ -1329,7 +1329,7 @@
     "description": "Boost::ASIO low-level redis client",
     "active": true
   },
-  
+
   {
     "name": "mruby-redis",
     "language": "mruby",
@@ -1338,7 +1338,7 @@
     "authors": ["matsumotory"],
     "active": true
   },
-  
+
     {
     "name": "mruby-hiredis",
     "language": "mruby",
@@ -1436,7 +1436,7 @@
     "authors": ["eyjian"],
     "active": true
   },
-  
+
   {
     "name": "rebridge",
     "language": "Node.js",
@@ -1471,7 +1471,7 @@
     "authors": ["etehtsea"],
     "active": true
   },
-  
+
   {
     "name": "oredis",
     "language": "PL/SQL",

--- a/clients.json
+++ b/clients.json
@@ -1479,5 +1479,14 @@
     "description": "Redis client library for Oracle PL/SQL. This support Redis cluster and asynchronous execution",
     "authors": ["SeyoungLee"],
     "active": true
+  },
+
+  {
+    "name": "aredis",
+    "language": "Python",
+    "repository": "https://github.com/NoneGG/aredis",
+    "description": "An efficient and user-friendly async redis client ported from redis-py.",
+    "authors": [],
+    "active": true
   }
 ]

--- a/clients.json
+++ b/clients.json
@@ -1471,6 +1471,26 @@
     "authors": ["etehtsea"],
     "active": true
   },
+  
+  {
+    "name": "RcppRedis",
+    "language": "R",
+    "url": "https://cran.rstudio.com/web/packages/RcppRedis/index.html",
+    "repository": "https://github.com/eddelbuettel/rcppredis",
+    "description": "R interface to Redis using the hiredis library.",
+    "authors": ["eddelbuettel"],
+    "active": true
+  },
+    
+  {
+    "name": "Redux",
+    "language": "R",
+    "url": "http://richfitz.github.io/redux/",
+    "repository": "https://github.com/richfitz/redux",
+    "description": "Provides a low-level interface to Redis, allowing execution of arbitrary Redis commands with almost no interface.",
+    "authors": ["rgfitzjohn"],
+    "active": true
+  },
 
   {
     "name": "oredis",

--- a/clients.json
+++ b/clients.json
@@ -1039,6 +1039,14 @@
     "description": "Redis client based on Finagle",
     "authors": []
   },
+  {
+      "name": "RedisCli",
+      "language": "R",
+      "repository": "https://bitbucket.org/cmbce/r-package-rediscli",
+      "description": "Basic client passing a (batch of) command(s) to redis-cli, getting back a (list of) character vector(s).",
+      "authors": ["CorentinBarbu"],
+      "active": true
+  },
 
   {
     "name": "rredis",

--- a/clients.json
+++ b/clients.json
@@ -1456,6 +1456,14 @@
   },
 
   {
+    "name": "hiredispool",
+    "language": "C",
+    "repository": "https://github.com/aclisp/hiredispool",
+    "description": "Provides connection pooling and auto-reconnect for hiredis. It is also minimalistic and easy to do customization.",
+    "active": true
+  },
+
+  {
     "name": "oxblood",
     "language": "Ruby",
     "repository": "https://github.com/etehtsea/oxblood",

--- a/clients.json
+++ b/clients.json
@@ -1323,6 +1323,14 @@
   },
 
   {
+    "name": "bredis",
+    "language": "C++",
+    "repository": "https://github.com/basiliscos/cpp-bredis",
+    "description": "Boost::ASIO low-level redis client",
+    "active": true
+  },
+  
+  {
     "name": "mruby-redis",
     "language": "mruby",
     "repository": "https://github.com/matsumoto-r/mruby-redis",

--- a/clients.json
+++ b/clients.json
@@ -805,12 +805,12 @@
   },
 
   {
-    "name": "redis-client for C++",
+    "name": "acl-redis",
     "language": "C++",
     "url": "https://github.com/zhengshuxin/acl/tree/master/lib_acl_cpp/samples/redis",
     "repository": "https://github.com/zhengshuxin/acl/tree/master/lib_acl_cpp/include/acl_cpp/redis",
-    "description": "Full Redis client commands, one redis command, one redis function",
-    "authors": [],
+    "description": "Standard C++ Redis Client with high performance and stl-like interface, supporting Redis Cluster, thread-safe",
+    "authors": ["zhengshuxin"],
     "active": true
   },
 

--- a/clients.json
+++ b/clients.json
@@ -559,15 +559,6 @@
   },
 
   {
-    "name": "scala-redis-client",
-    "language": "Scala",
-    "repository": "https://github.com/top10/scala-redis-client",
-    "description": "An idiomatic Scala client that keeps Jedis / Java hidden. Used in production at http://top10.com.",
-    "authors": ["thesmith", "heychinaski"],
-    "active": true
-  },
-
-  {
     "name": "scredis",
     "language": "Scala",
     "repository": "https://github.com/scredis/scredis",

--- a/clients.json
+++ b/clients.json
@@ -341,12 +341,13 @@
   },
 
   {
-    "name": "AnyEvent::Redis::RipeRedis",
+    "name": "AnyEvent::RipeRedis",
     "language": "Perl",
-    "url": "http://search.cpan.org/dist/AnyEvent-Redis-RipeRedis/",
-    "repository": "https://github.com/iph0/AnyEvent-Redis-RipeRedis",
-    "description": "Flexible non-blocking Redis client with reconnect feature",
-    "authors": ["iph"],
+    "url": "http://search.cpan.org/dist/AnyEvent-RipeRedis/",
+    "repository": "https://github.com/iph0/AnyEvent-RipeRedis",
+    "description": "Flexible non-blocking Redis client",
+    "authors": ["iph0"],
+    "recommended": true,
     "active": true
   },
 

--- a/clients.json
+++ b/clients.json
@@ -347,7 +347,16 @@
     "repository": "https://github.com/iph0/AnyEvent-RipeRedis",
     "description": "Flexible non-blocking Redis client",
     "authors": ["iph0"],
-    "recommended": true,
+    "active": true
+  },
+
+  {
+    "name": "AnyEvent::RipeRedis::Cluster",
+    "language": "Perl",
+    "url": "http://search.cpan.org/dist/AnyEvent-RipeRedis-Cluster/",
+    "repository": "https://github.com/iph0/AnyEvent-RipeRedis-Cluster",
+    "description": "Non-blocking Redis Cluster client",
+    "authors": ["iph0"],
     "active": true
   },
 

--- a/commands/command.md
+++ b/commands/command.md
@@ -99,7 +99,7 @@ Command flags is @array-reply containing one or more status replies:
 
 Some Redis commands have no predetermined key locations.  For those commands,
 flag `movablekeys` is added to the command flags @array-reply.  Your Redis
-Cluster client needs to parse commands marked `movabkeleys` to locate all relevant key positions.
+Cluster client needs to parse commands marked `movablekeys` to locate all relevant key positions.
 
 Complete list of commands currently requiring key location parsing:
 

--- a/commands/expire.md
+++ b/commands/expire.md
@@ -46,12 +46,14 @@ command altering its value had the effect of removing the key entirely.
 This semantics was needed because of limitations in the replication layer that
 are now fixed.
 
+`EXPIRE` would return 0 and not alter the timeout for a key with a timeout set.
+
 @return
 
 @integer-reply, specifically:
 
 * `1` if the timeout was set.
-* `0` if `key` does not exist or the timeout could not be set.
+* `0` if `key` does not exist.
 
 @examples
 

--- a/commands/expireat.md
+++ b/commands/expireat.md
@@ -20,7 +20,7 @@ a given time in the future.
 @integer-reply, specifically:
 
 * `1` if the timeout was set.
-* `0` if `key` does not exist or the timeout could not be set (see: `EXPIRE`).
+* `0` if `key` does not exist.
 
 @examples
 

--- a/commands/georadius.md
+++ b/commands/georadius.md
@@ -1,5 +1,7 @@
 Return the members of a sorted set populated with geospatial information using `GEOADD`, which are within the borders of the area specified with the center location and the maximum distance from the center (the radius).
 
+This manual page also covers the `GEORADIUS_RO` and `GEORADIUSBYRANGE_RO` variants (see the section below for more information).
+
 The common use case for this command is to retrieve geospatial items near a specified point and no far than a given amount of meters (or other units). This allows, for example, to suggest mobile users of an application nearby places.
 
 The radius is specified in one of the following units:
@@ -38,6 +40,14 @@ When additional information is returned as an array of arrays for each item, the
 So for example the command `GEORADIUS Sicily 15 37 200 km WITHCOORD WITHDIST` will return each item in the following way:
 
     ["Palermo","190.4424",["13.361389338970184","38.115556395496299"]]
+
+## Read only variants
+
+Since `GEORADIUS` and `GEORADIUSBYMEMBER` have a `STORE` and `STOREDIST` option they are technically flagged as writing commands in the Redis command table. For this reason read-only slaves will flag them, and Redis Cluster slaves will redirect them to the master instance even if the connection is in read only mode (See the `READONLY` command of Redis Cluster).
+
+Breaking the compatibility with the past was considered but rejected, at least for Redis 4.0, so instead two read only variants of the commands were added. They are exactly like the original commands but refuse the `STORE` and `STOREDIST` options. The two variants are called `GEORADIUS_RO` and `GEORADIUSBYMEMBER_RO`, and can safely be used in slaves.
+
+Both commands were introduced in Redis 3.2.10 and Redis 4.0.0 respectively.
 
 @examples
 

--- a/commands/georadiusbymember.md
+++ b/commands/georadiusbymember.md
@@ -5,6 +5,8 @@ The position of the specified member is used as the center of the query.
 
 Please check the example below and the `GEORADIUS` documentation for more information about the command and its options.
 
+Note that `GEORADIUSBYMEMBER_RO` is also available since Redis 3.2.10 and Redis 4.0.0 in order to provide a read-only command that can be used in slaves. See the `GEORADIUS` page for more information.
+
 @examples
 
 ```cli

--- a/commands/pexpire.md
+++ b/commands/pexpire.md
@@ -6,7 +6,7 @@ specified in milliseconds instead of seconds.
 @integer-reply, specifically:
 
 * `1` if the timeout was set.
-* `0` if `key` does not exist or the timeout could not be set.
+* `0` if `key` does not exist.
 
 @examples
 

--- a/commands/pexpireat.md
+++ b/commands/pexpireat.md
@@ -6,7 +6,7 @@ which the key will expire is specified in milliseconds instead of seconds.
 @integer-reply, specifically:
 
 * `1` if the timeout was set.
-* `0` if `key` does not exist or the timeout could not be set (see: `EXPIRE`).
+* `0` if `key` does not exist.
 
 @examples
 

--- a/modules.json
+++ b/modules.json
@@ -81,12 +81,12 @@
   },
 
   {
-    "name": "redablooms",
+    "name": "rebloom",
     "license" : "AGPL",
-    "repository": "https://github.com/RedisLabsModules/redablooms",
-    "description": "Scalable, counting Bloom filters",
-    "authors": ["itamarhaber", "RedisLabs"],
-    "stars": 15
+    "repository": "https://github.com/RedisLabsModules/rebloom",
+    "description": "Scalable Bloom filters",
+    "authors": ["mnunberg", "RedisLabs"],
+    "stars": 6
   },
 
   {

--- a/modules.json
+++ b/modules.json
@@ -105,5 +105,24 @@
     "description": "Time-series data structure for redis",
     "authors": ["danni-m"],
     "stars": 48
+  },
+
+  {
+    "name": "ReDe",
+    "license" : "MIT",
+    "repository": "https://github.com/TamarLabs/ReDe",
+    "description": "Low Latancy timed queues (Dehydrators) as Redis data types.",
+    "authors": ["daTokenizer"],
+    "stars": 6
+  },
+
+  {
+    "name": "commentDis",
+    "license" : "MIT",
+    "repository": "https://github.com/picotera/commentDis",
+    "description": "Add comment syntax to your redis-cli scripts.",
+    "authors": ["daTokenizer"],
+    "stars": 1
   }
+
 ]

--- a/modules.json
+++ b/modules.json
@@ -96,5 +96,14 @@
     "description": "Online trainable neural networks as Redis data types.",
     "authors": ["antirez"],
     "stars": 1854
+  },
+
+  {
+    "name": "redis-timerseries",
+    "license" : "AGPL",
+    "repository": "https://github.com/danni-m/redis-timeseries",
+    "description": "Time-series data structure for redis",
+    "authors": ["danni-m"],
+    "stars": 48
   }
 ]

--- a/tools.json
+++ b/tools.json
@@ -611,5 +611,12 @@
     "repository": "https://github.com/alicebob/miniredis",
     "description": "Pure Go Redis server for Go unittests",
     "authors": []
+  },
+  {
+    "name": "noncis",
+    "language": "Javascript",
+    "repository": "https://github.com/reidwmulkey/noncis",
+    "description": "Synchronizes nonces across node instances.",
+    "authors": []
   }
 ]

--- a/tools.json
+++ b/tools.json
@@ -597,5 +597,12 @@
     "repository": "https://github.com/vipshop/redis-migrate-tool",
     "description": "A convenient and useful tool for migrating data between redis groups.",
     "authors": ["diguo58"]
+  },
+  {
+    "name": "Regis",
+    "language": "Swift",
+    "url": "https://www.harfangapps.com/regis/",
+    "description": "Full-featured Redis client for the Mac, available on the Mac App Store.",
+    "authors": ["harfangapps"]
   }
 ]

--- a/tools.json
+++ b/tools.json
@@ -599,6 +599,14 @@
     "authors": ["diguo58"]
   },
   {
+    "name": "facil.io",
+    "language": "C",
+    "url": "http://facil.io/",
+    "repository": "https://github.com/boazsegev/facil.io",
+    "description": "facil.io includes an asynchronous Redis client as well as a RESP parser/formatter that can be used independently. It's MIT licensed and doesn't use hiredis.",
+    "authors": ["bowildmusic"]
+  },
+  {
     "name": "Regis",
     "language": "Swift",
     "url": "https://www.harfangapps.com/regis/",

--- a/tools.json
+++ b/tools.json
@@ -604,5 +604,12 @@
     "url": "https://www.harfangapps.com/regis/",
     "description": "Full-featured Redis client for the Mac, available on the Mac App Store.",
     "authors": ["harfangapps"]
+  },
+  {
+    "name": "miniredis",
+    "language": "Go",
+    "repository": "https://github.com/alicebob/miniredis",
+    "description": "Pure Go Redis server for Go unittests",
+    "authors": []
   }
 ]

--- a/topics/ARM.md
+++ b/topics/ARM.md
@@ -35,13 +35,13 @@ run as expected.
 There is nothing special in the process. The only difference is that by
 default, Redis uses the libc allocator instead of defaulting to Jemalloc
 as it does in other Linux based environments. This is because we believe
-that for the small use cases inside embeddeed devices, memory fragmentation
+that for the small use cases inside embedded devices, memory fragmentation
 is unlikely to be a problem. Moreover Jemalloc on ARM may not be as tested
 as the libc allocator.
 
 ## Performance
 
-Performance testing of Redis was performend in the Raspberry Pi 3 and in the
+Performance testing of Redis was performed in the Raspberry Pi 3 and in the
 original model B Pi. The difference between the two Pis in terms of
 delivered performance is quite big. The benchmarks were performed via the
 loopback interface, since most use cases will probably use Redis from within

--- a/topics/ARM.md
+++ b/topics/ARM.md
@@ -1,8 +1,8 @@
 # Redis on ARM
 
 Since the Redis 4.0 version (currently in release candidate state) Redis
-supports the ARM processor, and the Raspberry Pi, as a main
-platform, exactly like it happens for Linux/x86. It means that every new
+supports the ARM processor in general, and the Raspberry Pi specifically, as a
+main platform, exactly like it happens for Linux/x86. It means that every new
 release of Redis is tested on the Pi environment, and that we take
 this documentation page updated with information about supported devices
 and information. While Redis already runs on Android, in the future we look

--- a/topics/clients.md
+++ b/topics/clients.md
@@ -161,4 +161,11 @@ See the [CLIENT LIST](http://redis.io/commands/client-list) documentation for th
 
 Once you have the list of clients, you can easily close the connection with a client using the `CLIENT KILL` command specifying the client address as argument.
 
-The commands `CLIENT SETNAME` and `CLIENT GETNAME` can be used to set and get the connection name.
+The commands `CLIENT SETNAME` and `CLIENT GETNAME` can be used to set and get the connection name. Starting with Redis 4.0, the client name is shown in the
+`SLOWLOG` output, so that it gets simpler to identify clients that are creating
+latency issues.
+
+TCP keepalive
+---
+
+Recent versions of Redis (3.2 or greater) have TCP keepalive (`SO_KEEPALIVE` socket option) enabled by default and set to about 300 seconds. This option is useful in order to detect dead peers (clients that cannot be reached even if they look connected). Moreover, if there is network equipment between clients and servers that need to see some traffic in order to take the connection open, the option will prevent unexpected connection closed events.

--- a/topics/clients.md
+++ b/topics/clients.md
@@ -46,14 +46,14 @@ However Redis does the following two things when serving clients:
 Maximum number of clients
 ---
 
-In Redis 2.4 there was an hard-coded limit about the maximum number of clients
-that was possible to handle simultaneously.
+In Redis 2.4 there was a hard-coded limit for the maximum number of clients
+that could be handled simultaneously.
 
-In Redis 2.6 this limit is dynamic: by default is set to 10000 clients, unless
+In Redis 2.6 this limit is dynamic: by default it is set to 10000 clients, unless
 otherwise stated by the `maxclients` directive in Redis.conf.
 
-However Redis checks with the kernel what is the maximum number of file
-descriptors that we are able to open (the *soft limit* is checked), if the
+However, Redis checks with the kernel what is the maximum number of file
+descriptors that we are able to open (the *soft limit* is checked). If the
 limit is smaller than the maximum number of clients we want to handle, plus
 32 (that is the number of file descriptors Redis reserves for internal uses),
 then the number of maximum clients is modified by Redis to match the amount

--- a/topics/cluster-spec.md
+++ b/topics/cluster-spec.md
@@ -895,7 +895,7 @@ This section illustrates how the epoch concept is used to make the slave promoti
 
 At this point B is down and A is available again with a role of master (actually `UPDATE` messages would reconfigure it promptly, but here we assume all `UPDATE` messages were lost). At the same time, slave C will try to get elected in order to fail over B. This is what happens:
 
-1. B will try to get elected and will succeed, since for the majority of masters its master is actually down. It will obtain a new incremental `configEpoch`.
+1. C will try to get elected and will succeed, since for the majority of masters its master is actually down. It will obtain a new incremental `configEpoch`.
 2. A will not be able to claim to be the master for its hash slots, because the other nodes already have the same hash slots associated with a higher configuration epoch (the one of B) compared to the one published by A.
 3. So, all the nodes will upgrade their table to assign the hash slots to C, and the cluster will continue its operations.
 

--- a/topics/cluster-spec.md
+++ b/topics/cluster-spec.md
@@ -486,9 +486,9 @@ there are no race conditions). This is how `MIGRATE` works:
     MIGRATE target_host target_port key target_database id timeout
 
 `MIGRATE` will connect to the target instance, send a serialized version of
-the key, and once an OK code is received will delete the old key from its own
-dataset. From the point of view of an external client a key exists either
-in A or B at any given time.
+the key, and once an OK code is received, the old key from its own dataset
+will be deleted. From the point of view of an external client a key exists
+either in A or B at any given time.
 
 In Redis Cluster there is no need to specify a database other than 0, but
 `MIGRATE` is a general command that can be used for other tasks not

--- a/topics/data-types-intro.md
+++ b/topics/data-types-intro.md
@@ -83,7 +83,7 @@ already stored into the key, in the case that the key already exists, even if
 the key is associated with a non-string value. So `SET` performs an assignment.
 
 Values can be strings (including binary data) of every kind, for instance you
-can store a jpeg image inside a key. A value can't be bigger than 512 MB.
+can store a jpeg image inside a value. A value can't be bigger than 512 MB.
 
 The `SET` command has interesting options, that are provided as additional
 arguments. For example, I may ask `SET` to fail if the key already exists,

--- a/topics/data-types-intro.md
+++ b/topics/data-types-intro.md
@@ -875,7 +875,7 @@ the `+` and `-` strings. See the documentation for more information.
 This feature is important because it allows us to use sorted sets as a generic
 index. For example, if you want to index elements by a 128-bit unsigned
 integer argument, all you need to do is to add elements into a sorted
-set with the same score (for example 0) but with an 8 byte prefix
+set with the same score (for example 0) but with an 16 byte prefix
 consisting of **the 128 bit number in big endian**. Since numbers in big
 endian, when ordered lexicographically (in raw bytes order) are actually
 ordered numerically as well, you can ask for ranges in the 128 bit space,

--- a/topics/faq.md
+++ b/topics/faq.md
@@ -7,20 +7,23 @@ There are two main reasons.
 * Redis is a different evolution path in the key-value DBs where values can contain more complex data types, with atomic operations defined on those data types. Redis data types are closely related to fundamental data structures and are exposed to the programmer as such, without additional abstraction layers.
 * Redis is an in-memory but persistent on disk database, so it represents a different trade off where very high write and read speed is achieved with the limitation of data sets that can't be larger than memory. Another advantage of
 in memory databases is that the memory representation of complex data structures
-is much simpler to manipulate compared to the same data structure on disk, so
+is much simpler to manipulate compared to the same data structures on disk, so
 Redis can do a lot, with little internal complexity. At the same time the
 two on-disk storage formats (RDB and AOF) don't need to be suitable for random
 access, so they are compact and always generated in an append-only fashion
 (Even the AOF log rotation is an append-only operation, since the new version
-is generated from the copy of data in memory).
+is generated from the copy of data in memory). However this design also involves
+different challenges compared to traditional on-disk stores. Being the main data
+representation on memory, Redis operations must be carefully handled to make sure
+there is always an updated version of the data set on disk.
 
 ## What's the Redis memory footprint?
 
 To give you a few examples (all obtained using 64-bit instances):
 
-* An empty instance uses ~ 1MB of memory.
-* 1 Million small Keys -> String Value pairs use ~ 100MB of memory.
-* 1 Million Keys -> Hash value, representing an object with 5 fields, use ~ 200 MB of memory.
+* An empty instance uses ~ 3MB of memory.
+* 1 Million small Keys -> String Value pairs use ~ 85MB of memory.
+* 1 Million Keys -> Hash value, representing an object with 5 fields, use ~ 160 MB of memory.
 
 To test your use case is trivial using the `redis-benchmark` utility to generate random data sets and check with the `INFO memory` command the space used.
 
@@ -36,12 +39,22 @@ If your real problem is not the total RAM needed, but the fact that you need
 to split your data set into multiple Redis instances, please read the
 [Partitioning page](/topics/partitioning) in this documentation for more info.
 
+Recently Redis Labs, the company sponsoring Redis developments, developed a
+"Redis on flash" solution that is able to use a mixed RAM/flash approach for
+larger data sets with a biased access pattern. You may check their offering
+for more information, however this feature is not part of the open source Redis
+code base.
+
 ## Is using Redis together with an on-disk database a good idea?
 
 Yes, a common design pattern involves taking very write-heavy small data
 in Redis (and data you need the Redis data structures to model your problem
 in an efficient way), and big *blobs* of data into an SQL or eventually
-consistent on-disk database.
+consistent on-disk database. Similarly sometimes Redis is used in order to
+take in memory another copy of a subset of the same data stored in the on-disk
+database. This may look similar to caching, but actually is a more advanced model
+since normally the Redis dataset is updated together with the on-disk DB dataset,
+and not refreshed on cache misses.
 
 ## Is there something I can do to lower the Redis memory usage?
 
@@ -55,20 +68,22 @@ way. There is more info in the [Memory Optimization page](/topics/memory-optimiz
 Redis will either be killed by the Linux kernel OOM killer,
 crash with an error, or will start to slow down.
 With modern operating systems malloc() returning NULL is not common, usually
-the server will start swapping, and Redis performance will degrade, so
-you'll probably notice there is something wrong.
-
-The INFO command will report the amount of memory Redis is using so you can
-write scripts that monitor your Redis servers checking for critical conditions.
+the server will start swapping (if some swap space is configured), and Redis
+performance will start to degrade, so you'll probably notice there is something
+wrong.
 
 Redis has built-in protections allowing the user to set a max limit to memory
-usage, using the `maxmemory` option in the config file to put a limit
+usage, using the `maxmemory` option in the configuration file to put a limit
 to the memory Redis can use. If this limit is reached Redis will start to reply
 with an error to write commands (but will continue to accept read-only
 commands), or you can configure it to evict keys when the max memory limit
 is reached in the case you are using Redis for caching.
 
-We have documentation if you plan to use [Redis as an LRU cache](/topics/lru-cache).
+We have detailed documentation in case you plan to use [Redis as an LRU cache](/topics/lru-cache).
+
+The INFO command will report the amount of memory Redis is using so you can
+write scripts that monitor your Redis servers checking for critical conditions
+before they are reached.
 
 ## Background saving fails with a fork() error under Linux even if I have a lot of free RAM!
 
@@ -111,8 +126,8 @@ in RAM is also atomic from the point of view of the disk snapshot.
 
 ## Redis is single threaded. How can I exploit multiple CPU / cores?
 
-It's very unlikely that CPU becomes your bottleneck with Redis, as usually Redis is either memory or network bound. For instance, using pipelining Redis running
-on an average Linux system can deliver even 500k requests per second, so
+It's not very frequent that CPU becomes your bottleneck with Redis, as usually Redis is either memory or network bound. For instance, using pipelining Redis running
+on an average Linux system can deliver even 1 million requests per second, so
 if your application mainly uses O(N) or O(log(N)) commands, it is hardly
 going to use too much CPU.
 
@@ -122,6 +137,11 @@ box may not be enough anyway, so if you want to use multiple CPUs you can
 start thinking of some way to shard earlier.
 
 You can find more information about using multiple Redis instances in the [Partitioning page](/topics/partitioning).
+
+However with Redis 4.0 we started to make Redis more threaded. For now this is
+limited to deleting objects in the background, and to blocking commands
+implemented via Redis modules. For the next releases, the plan is to make Redis
+more and more threaded.
 
 ## What is the maximum number of keys a single Redis instance can hold? and what the max number of elements in a Hash, List, Set, Sorted Set?
 

--- a/topics/indexes.md
+++ b/topics/indexes.md
@@ -644,7 +644,7 @@ What we do is to start with the left bottom corner of our search box,
 which is 50,100, and find the first range by substituting the last 6 bits
 in each number with 0. Then we do the same with the right top corner.
 
-With two trivial nested for loops where we increment only the significative
+With two trivial nested for loops where we increment only the significant
 bits, we can find all the squares between these two. For each square we
 convert the two numbers into our interleaved representation, and create
 the range using the converted representation as our start, and the same
@@ -687,7 +687,7 @@ Turning this into code is simple. Here is a Ruby example:
 
 While non immediately trivial this is a very useful indexing strategy that
 in the future may be implemented in Redis in a native way.
-For now, the good thing is that the complexity may be easily encapsualted
+For now, the good thing is that the complexity may be easily encapsulated
 inside a library that can be used in order to perform indexing and queries.
 One example of such library is [Redimension](https://github.com/antirez/redimension), a proof of concept Ruby library which indexes N-dimensional data inside Redis using the technique described here.
 

--- a/topics/lru-cache.md
+++ b/topics/lru-cache.md
@@ -47,11 +47,11 @@ configured using the `maxmemory-policy` configuration directive.
 The following policies are available:
 
 * **noeviction**: return errors when the memory limit was reached and the client is trying to execute commands that could result in more memory to be used (most write commands, but `DEL` and a few more exceptions).
-* **allkeys-lru**: evict keys trying to remove the less recently used (LRU) keys first, in order to make space for the new data added.
-* **volatile-lru**: evict keys trying to remove the less recently used (LRU) keys first, but only among keys that have an **expire set**, in order to make space for the new data added.
-* **allkeys-random**: evict random keys in order to make space for the new data added.
-* **volatile-random**: evict random keys in order to make space for the new data added, but only evict keys with an **expire set**.
-* **volatile-ttl**: In order to make space for the new data, evict only keys with an **expire set**, and try to evict keys with a shorter time to live (TTL) first.
+* **allkeys-lru**: evict keys by trying to remove the less recently used (LRU) keys first, in order to make space for the new data added.
+* **volatile-lru**: evict keys by trying to remove the less recently used (LRU) keys first, but only among keys that have an **expire set**, in order to make space for the new data added.
+* **allkeys-random**: evict keys randomly in order to make space for the new data added.
+* **volatile-random**: evict keys randomly in order to make space for the new data added, but only evict keys with an **expire set**.
+* **volatile-ttl**: evict keys with an **expire set**, and try to evict keys with a shorter time to live (TTL) first, in order to make space for the new data added.
 
 The policies **volatile-lru**, **volatile-random** and **volatile-ttl** behave like **noeviction** if there are no keys to evict matching the prerequisites.
 

--- a/topics/pipelining.md
+++ b/topics/pipelining.md
@@ -1,5 +1,8 @@
-Request/Response protocols and RTT
+Using pipelining to speedup Redis queries
 ===
+
+Request/Response protocols and RTT
+---
 
 Redis is a TCP server using the client-server model and what is called a *Request/Response* protocol.
 
@@ -127,3 +130,32 @@ Pipelining VS Scripting
 Using [Redis scripting](/commands/eval) (available in Redis version 2.6 or greater) a number of use cases for pipelining can be addressed more efficiently using scripts that perform a lot of the work needed at the server side. A big advantage of scripting is that it is able to both read and write data with minimal latency, making operations like *read, compute, write* very fast (pipelining can't help in this scenario since the client needs the reply of the read command before it can call the write command).
 
 Sometimes the application may also want to send `EVAL` or `EVALSHA` commands in a pipeline. This is entirely possible and Redis explicitly supports it with the [SCRIPT LOAD](http://redis.io/commands/script-load) command (it guarantees that `EVALSHA` can be called without the risk of failing).
+
+Appendix: why a busy loops are slow even on the loopback interface?
+---
+
+Even with all the background covered in this page, you may still wonder why
+a Redis benchmark like the following (in pseudo code), is slow even when
+executed in the loopback interface, when the server and the client are running
+in the same physical machine:
+
+    FOR-ONE-SECOND:
+        Redis.SET("foo","bar")
+    END
+
+After all if both the Redis process and the benchmark are running in the same
+box, isn't this just messages copied via memory from one place to another without
+any actual latency and actual networking involved?
+
+The reason is that processes in a system are not always running, actually it is
+the kernel scheduler that let the process run, so what happens is that, for
+instance, the benchmark is allowed to run, reads the reply from the Redis server
+(related to the last command executed), and writes a new command. The command is
+now in the loopback interface buffer, but in order to be read by the server, the
+kernel should schedule the server process (currently blocked in a system call)
+to run, and so forth. So in practical terms the loopback interface still involves
+network-alike latency, because of how the kernel scheduler works.
+
+Basically a busy loop benchmark is the silliest thing that can be done when
+metering performances in a networked server. The wise thing is just avoiding
+benchmarking in this way.

--- a/topics/rediscli.md
+++ b/topics/rediscli.md
@@ -679,7 +679,7 @@ name is simply `--slave`. This is how it works:
     "SELECT","0"
     "set","foo","bar"
     "PING"
-    "incr","myconuter"
+    "incr","mycounter"
 
 The command begins by discarding the RDB file of the first synchronization
 and then logs each command received as in CSV format.

--- a/topics/replication.md
+++ b/topics/replication.md
@@ -1,35 +1,54 @@
 Replication
 ===
 
-Redis replication is a very simple to use and configure master-slave
-replication that allows slave Redis servers to be exact copies of
-master servers. The following are some very important facts about Redis
-replication:
+At the base of Redis replication there is a very simple to use and configure
+master-slave replication that allows slave Redis servers to be exact copies of
+master servers. The slave will automatically reconnect to the master every
+time the link breaks, and will attempt to be an exact copy of it regardless
+of what happens to the master.
 
-* Redis uses asynchronous replication. Starting with Redis 2.8,
-however, slaves periodically acknowledge the amount of data
-processed from the replication stream.
+This system works using three main mechanisms:
+
+1. When a master and a slave instance are well-connected, the master keeps the slave updated by sending a stream of commands in order to replicate the effects on the dataset happening in the master dataset: client writes, keys expiring or evicted, and so forth.
+2. When the link between the master and the slave breaks, for network issues or because a timeout is sensed in the master or the slave, the slave reconnects and attempts to proceed with a partial resynchronization: it means that it will try to just obtain the part of the stream of commands it missed during the disconnection.
+3. When a partial resynchronization is not possible, the slave will ask for a full resynchronization. This will involve a more complex process in which the master needs to create a snapshot of all its data, send it to the slave, and then continue sending the stream of commands as the dataset changes.
+
+Redis uses by default asynchronous replication, which being high latency and
+high performance, is the natural replication mode for the vast majority of Redis
+use cases. However Redis slaves asynchronously acknowledge the amount of data
+the received periodically with the master.
+
+Synchronous replication of certain data can be requested by the clients using
+the `WAIT` command. However `WAIT` is only able to ensure that there are the
+specified number of acknowledged copies in the other Redis instances: acknowledged
+writes can still be lost during a failover for different reasons during a
+failover or depending on the exact configuration of the Redis persistence.
+You could check the Sentinel or Redis Cluster documentation for more information
+about high availability and failover. The rest of this document mainly describe the basic characteristics of Redis basic replication.
+
+The following are some very important facts about Redis replication:
+
+* Redis uses asynchronous replication, with asynchronous slave-to-master acknowledges of the amount of data processed.
 
 * A master can have multiple slaves.
 
 * Slaves are able to accept connections from other slaves. Aside from
 connecting a number of slaves to the same master, slaves can also be
-connected to other slaves in a cascading-like structure.
+connected to other slaves in a cascading-like structure. Since Redis 4.0, all the sub-slaves will receive exactly the same replication stream from the master.
 
 * Redis replication is non-blocking on the master side. This means that
 the master will continue to handle queries when one or more slaves perform
-the initial synchronization.
+the initial synchronization or a partial resynchronization.
 
-* Replication is also non-blocking on the slave side. While the slave is performing the initial synchronization, it can handle queries using the old version of
-the dataset, assuming you configured Redis to do so in redis.conf.
+* Replication is also largely non-blocking on the slave side. While the slave is performing the initial synchronization, it can handle queries using the old version of the dataset, assuming you configured Redis to do so in redis.conf.
 Otherwise, you can configure Redis slaves to return an error to clients if the
 replication stream is down. However, after the initial sync, the old dataset
 must be deleted and the new one must be loaded. The slave will block incoming
-connections during this brief window (that can be as long as many seconds for very large datasets).
+connections during this brief window (that can be as long as many seconds for very large datasets). Since Redis 4.0 it is possible to configure Redis so that the deletion of the old data set happens in a different thread, however loading the new initial dataset will still happen in the main thread and block the slave.
 
 * Replication can be used both for scalability, in order to have
 multiple slaves for read-only queries (for example, slow O(N)
-operations can be offloaded to slaves), or simply for data redundancy.
+operations can be offloaded to slaves), or simply for data safety.
 
 * It is possible to use replication to avoid the cost of having the master write the full dataset to disk: a typical technique involves configuring your master `redis.conf` to avoid persisting to disk at all, then connect a slave configured to save from time to time, or with AOF enabled. However this setup must be handled with care, since a restarting master will start with an empty dataset: if the slave tries to synchronized with it, the slave will be emptied as well.
 
@@ -37,16 +56,17 @@ Safety of replication when master has persistence turned off
 ---
 
 In setups where Redis replication is used, it is strongly advised to have
-persistence turned on in the master, or when this is not possible, for example
-because of latency concerns, instances should be configured to **avoid restarting automatically** after a reboot.
+persistence turned on in the master and in the slaves. When this is not possible,
+for example because of latency concerns due to very slow disks, instances should
+be configured to **avoid restarting automatically** after a reboot.
 
 To better understand why masters with persistence turned off configured to
 auto restart are dangerous, check the following failure mode where data
 is wiped from the master and all its slaves:
 
 1. We have a setup with node A acting as master, with persistence turned down, and nodes B and C replicating from node A.
-2. A crashes, however it has some auto-restart system, that restarts the process. However since persistence is turned off, the node restarts with an empty data set.
-3. Nodes B and C will replicate from A, which is empty, so they'll effectively destroy their copy of the data.
+2. Node A crashes, however it has some auto-restart system, that restarts the process. However since persistence is turned off, the node restarts with an empty data set.
+3. Nodes B and C will replicate from node A, which is empty, so they'll effectively destroy their copy of the data.
 
 When Redis Sentinel is used for high availability, also turning off persistence
 on the master, together with auto restart of the process, is dangerous. For example the master can restart fast enough for Sentinel to don't detect a failure, so that the failure mode described above happens.
@@ -56,48 +76,36 @@ Every time data safety is important, and replication is used with master configu
 How Redis replication works
 ---
 
-If you set up a slave, upon connection it sends a PSYNC command.
+Every Redis master has a replication ID: it is a large pseudo random string
+that marks a given story of the dataset. Each master also takes an offset that
+increments for every byte of replication stream that it is produced to be
+sent to slaves, in order to update the state of the slaves with the new changes
+modifying the dataset. The replication offset is incremented even if no slave
+is actually connected, so basically every given pair of:
 
-If this is a reconnection and the master has enough *backlog*, only the difference (what the slave missed) is sent. Otherwise what is called a *full resynchronization* is triggered.
+    Replication ID, offset
 
-When a full resynchronization is triggered, the master starts a background
-saving process in order to produce an RDB file. At the same time it starts to
-buffer all new write commands received from the clients. When the background
-saving is complete, the master transfers the database file to the slave,
-which saves it on disk, and then loads it into memory. The master will
-then send all buffered commands to the slave. This is done as a
-stream of commands and is in the same format of the Redis protocol itself.
+Identifies an exact version of the dataset of a master.
+
+When slaves connects to master, they use the `PSYNC` command in order to send
+their old master replication ID and the offsets they processed so far. This way
+the master can send just the incremental part needed. However if there is not
+enough *backlog* in the master buffers, or if the slave is referring to an
+history (replication ID) which is no longer known, than a full resynchronization
+happens: in this case the slave will get a full copy of the dataset, from scratch.
+
+This is how a full synchronization works in more details:
+
+The master starts a background saving process in order to produce an RDB file. At the same time it starts to buffer all new write commands received from the clients. When the background saving is complete, the master transfers the database file to the slave, which saves it on disk, and then loads it into memory. The master will then send all buffered commands to the slave. This is done as a stream of commands and is in the same format of the Redis protocol itself.
 
 You can try it yourself via telnet. Connect to the Redis port while the
 server is doing some work and issue the `SYNC` command. You'll see a bulk
 transfer and then every command received by the master will be re-issued
-in the telnet session.
+in the telnet session. Actually `SYNC` is an old protocol no longer used by
+newer Redis instances, but is still there for backward compatibility: it does
+not allow partial resynchronizations, so now `PSYNC` is used instead.
 
-Slaves are able to automatically reconnect when the master-slave
-link goes down for some reason. If the master receives multiple
-concurrent slave synchronization requests, it performs a single
-background save in order to serve all of them.
-
-Partial resynchronization
----
-
-Starting with Redis 2.8, master and slave are usually able to continue the
-replication process without requiring a full resynchronization after the
-replication link went down.
-
-This works by creating an in-memory backlog of the replication stream on the
-master side. The master and all the slaves agree on a *replication
-offset* and a *master run ID*, so when the link goes down, the slave will
-reconnect and ask the master to continue the replication. Assuming the
-master run ID is still the same, and that the offset specified is available
-in the replication backlog, replication will resume from the point where it left off.
-If either of these conditions are unmet, a full resynchronization is performed
-(which is the normal pre-2.8 behavior). As the run ID of the connected master is not persisted to disk, a full resynchronization is needed when the slave restarts.
-
-The new partial resynchronization feature uses the `PSYNC` command internally,
-while the old implementation uses the `SYNC` command. Note that a Redis
-slave is able to detect if the server it is talking with does not support
-`PSYNC`, and will use `SYNC` instead.
+As already said, slaves are able to automatically reconnect when the master-slave link goes down for some reason. If the master receives multiple concurrent slave synchronization requests, it performs a single background save in order to serve all of them.
 
 Diskless replication
 ---
@@ -113,8 +121,7 @@ RDB over the wire to slaves, without using the disk as intermediate storage.
 Configuration
 ---
 
-To configure replication is trivial: just add the following line to the slave
-configuration file:
+To configure basic Redis replication is trivial: just add the following line to the slave configuration file:
 
     slaveof 192.168.1.1 6379
 
@@ -141,17 +148,16 @@ This behavior is controlled by the `slave-read-only` option in the redis.conf fi
 Read-only slaves will reject all write commands, so that it is not possible to write to a slave because of a mistake. This does not mean that the feature is intended to expose a slave instance to the internet or more generally to a network where untrusted clients exist, because administrative commands like `DEBUG` or `CONFIG` are still enabled. However, security of read-only instances can be improved by disabling commands in redis.conf using the `rename-command` directive.
 
 You may wonder why it is possible to revert the read-only setting
-and have slave instances that can be target of write operations.
+and have slave instances that can be targeted by write operations.
 While those writes will be discarded if the slave and the master
 resynchronize or if the slave is restarted, there are a few legitimate
 use case for storing ephemeral data in writable slaves.
 
-For example computing slow set or zset operations and storing them into local
-keys is an use case for writable slaves that was observed multiple times.
+For example computing slow Set or Sorted set operations and storing them into local keys is an use case for writable slaves that was observed multiple times.
 
 However note that **writable slaves before version 4.0 were uncapable of expiring keys with a time to live set**. This means that if you use `EXPIRE` or other commands that set a maximum TTL for a key, the key will leak, and while you may no longer see it while accessing it with read commands, you will see it in the count of keys and it will still use memory. So in general mixing writable slaves (previous version 4.0) and keys with TTL is going to create issues.
 
-Redis 4.0 RC3 and greater totally resolve this problem and now writable
+Redis 4.0 RC3 and greater versions totally solve this problem and now writable
 slaves are able to evict keys with TTL as masters do, with the exceptions
 of keys written in DB numbers greater than 63 (but by default Redis instances
 only have 16 databases).
@@ -195,9 +201,7 @@ This is how the feature works:
 
 If there are at least N slaves, with a lag less than M seconds, then the write will be accepted.
 
-You may think of it as a relaxed version of the "C" in the CAP theorem, where
-consistency is not ensured for a given write, but at least the time window for
-data loss is restricted to a given number of seconds.
+You may think of it as a best effort data safety mechanism, where consistency is not ensured for a given write, but at least the time window for data loss is restricted to a given number of seconds. In general bound data loss is better than unbound one.
 
 If the conditions are not met, the master will instead reply with an error and the write will not be accepted.
 
@@ -252,3 +256,34 @@ The two configurations directives to use are:
     slave-announce-port 1234
 
 And are documented in the example `redis.conf` of recent Redis distributions.
+
+The INFO and ROLE command
+---
+
+There are two Redis commands that provide a lot of information on the current
+replication parameters of master and slave instances. One is `INFO`. If the
+command is called with the `replication` argument as `INFO replication` only
+information relevant to the replication are displayed. Another more
+computer-friendly command is `ROLE`, that provides the replication status of
+masters and slaves together with their replication offsets, list of connected
+slaves and so forth.
+
+Partial resynchronizations after restarts and failovers
+---
+
+Since Redis 4.0, when an instance instance is promoted to master after a failover,
+it will be still able to perform a partial resynchronization with the slaves
+of the old master. To do so, the slave remembers the old replication ID and
+offset of its former master, so can provide part of the backlog to the connecting
+slaves even if they ask for the old replication ID.
+
+However the new replication ID of the promoted slave will be different, since it
+constitutes a different history of the data set. For example, the master can
+return available and can continue accepting writes for some time, so using the
+same replication ID in the promoted slave would violate the rule that a
+of replication ID and offset pair identifies only a single data set.
+
+Moreover slaves when powered off gently and restarted, are able to store in the
+`RDB` file the information needed in order to resynchronize with their master.
+This is useful in case of upgrades. When this is needed, it is better to use
+the `SHUTDOWN` command in order to perform a `save & quit` operation on the slave.

--- a/topics/replication.md
+++ b/topics/replication.md
@@ -155,7 +155,7 @@ use case for storing ephemeral data in writable slaves.
 
 For example computing slow Set or Sorted set operations and storing them into local keys is an use case for writable slaves that was observed multiple times.
 
-However note that **writable slaves before version 4.0 were uncapable of expiring keys with a time to live set**. This means that if you use `EXPIRE` or other commands that set a maximum TTL for a key, the key will leak, and while you may no longer see it while accessing it with read commands, you will see it in the count of keys and it will still use memory. So in general mixing writable slaves (previous version 4.0) and keys with TTL is going to create issues.
+However note that **writable slaves before version 4.0 were incapable of expiring keys with a time to live set**. This means that if you use `EXPIRE` or other commands that set a maximum TTL for a key, the key will leak, and while you may no longer see it while accessing it with read commands, you will see it in the count of keys and it will still use memory. So in general mixing writable slaves (previous version 4.0) and keys with TTL is going to create issues.
 
 Redis 4.0 RC3 and greater versions totally solve this problem and now writable
 slaves are able to evict keys with TTL as masters do, with the exceptions

--- a/topics/replication.md
+++ b/topics/replication.md
@@ -231,7 +231,7 @@ able to work:
 2. However because of master-driven expire, sometimes slaves may still have in memory keys that are already logically expired, since the master was not able to provide the `DEL` command in time. In order to deal with that the slave uses its logical clock in order to report that a key does not exist **only for read operations** that don't violate the consistency of the data set (as new commands from the master will arrive). In this way slaves avoid to report logically expired keys are still existing. In practical terms, an HTML fragments cache that uses slaves to scale will avoid returning items that are already older than the desired time to live.
 3. During Lua scripts executions no keys expires are performed. As a Lua script runs, conceptually the time in the master is frozen, so that a given key will either exist or not for all the time the script runs. This prevents keys to expire in the middle of a script, and is needed in order to send the same script to the slave in a way that is guaranteed to have the same effects in the data set.
 
-As it is expected, once a slave is turned into a master because of a fail over, it start to expire keys in an independent way without requiring help from its old master.
+Once a slave is promoted to a master it will start to expire keys independently, and will not require any help from its old master.
 
 Configuring replication in Docker and NAT
 ---

--- a/topics/twitter-clone.md
+++ b/topics/twitter-clone.md
@@ -265,7 +265,7 @@ This is the actual code:
         goback("Wrong username or password");
     $realpassword = $r->hget("user:$userid","password");
     if ($realpassword != $password)
-        goback("Wrong useranme or password");
+        goback("Wrong username or password");
 
     # Username / password OK, set the cookie and redirect to index.php
     $authsecret = $r->hget("user:$userid","auth");

--- a/topics/twitter-clone.md
+++ b/topics/twitter-clone.md
@@ -1,14 +1,14 @@
 Tutorial: Design and implementation of a simple Twitter clone using PHP and the Redis key-value store
 ===
 
-This article describes the design and implementation of a [very simple Twitter clone](https://github.com/antirez/retwis) written using PHP with Redis as the only database. The programming community has traditionally considered key-value stores as a special purpose database that couldn't be used as a drop in replacement for a relational database for the development of web applications. This article will try to show that Redis data structures on top of a key-value layer are an effective data model to implement many kinds of applications.
+This article describes the design and implementation of a [very simple Twitter clone](https://github.com/antirez/retwis) written using PHP with Redis as the only database. The programming community has traditionally considered key-value stores as a special purpose database that couldn't be used as a drop-in replacement for a relational database for the development of web applications. This article will try to show that Redis data structures on top of a key-value layer are an effective data model to implement many kinds of applications.
 
-Before to continue, you may want to play a few seconds with [the Retwis online demo](http://retwis.redis.io), to check what we are going to actually
+Before continuing, you may want to spend a few seconds playing with [the Retwis online demo](http://retwis.redis.io), to check what we are going to actually
 model. Long story short: it is a toy, but complex enough to be a foundation
 in order to learn how to create more complex applications.
 
 Note: the original version of this article was written in 2009 when Redis was
-released. It was not exactly clear at the time that the Redis data model was
+released. It was not exactly clear at that time that the Redis data model was
 suitable to write entire applications. Now after 5 years there are many cases of
 applications using Redis as their main store, so the goal of the article today
 is to be a tutorial for Redis newcomers. You'll learn how to design a simple
@@ -16,7 +16,7 @@ data layout using Redis, and how to apply different data structures.
 
 Our Twitter clone, called [Retwis](http://retwis.antirez.com), is structurally simple, has very good performance, and can be distributed among any number of web and Redis servers with little efforts. You can find the source code [here](http://code.google.com/p/redis/downloads/list).
 
-I use PHP for the example since it can be read by everybody. The same (or better) results can be obtained using Ruby, Python, Erlang, and so on.
+I used PHP for the example since it can be read by everybody. The same (or better) results can be obtained using Ruby, Python, Erlang, and so on.
 A few clones exist (however not all the clones use the same data layout as the
 current version of this tutorial, so please, stick with the official PHP
 implementation for the sake of following the article better).
@@ -24,9 +24,9 @@ implementation for the sake of following the article better).
 * [Retwis-RB](http://retwisrb.danlucraft.com/) is a port of Retwis to Ruby and Sinatra written by Daniel Lucraft! Full source code is included of course, and a link to its Git repository appears in the footer of this article. The rest of this article targets PHP, but Ruby programmers can also check the Retwis-RB source code since it's conceptually very similar.
 * [Retwis-J](http://retwisj.cloudfoundry.com/) is a port of Retwis to Java, using the Spring Data Framework, written by [Costin Leau](http://twitter.com/costinl). Its source code can be found on [GitHub](https://github.com/SpringSource/spring-data-keyvalue-examples), and there is comprehensive documentation available at [springsource.org](http://j.mp/eo6z6I).
 
-What is a Key-value store?
+What is a key-value store?
 ---
-The essence of a key-value store is the ability to store some data, called a _value_, inside a key. The value can be retrieved later only if we know the specific key it was stored in. There is no direct way to search for a key by value. In a sense, it is like a very large hash/dictionary, but it is persistent, i.e. when your application ends, the data doesn't go away. So, for example, I can use the command `SET` to store the value *bar* in the key *foo*:
+The essence of a key-value store is the ability to store some data, called a _value_, inside a key. The value can be retrieved later only if we know the specific key it was stored in. There is no direct way to search for a key by value. In some sense, it is like a very large hash/dictionary, but it is persistent, i.e. when your application ends, the data doesn't go away. So, for example, I can use the command `SET` to store the value *bar* in the key *foo*:
 
     SET foo bar
 
@@ -44,7 +44,7 @@ Other common operations provided by key-value stores are `DEL`, to delete a give
 Atomic operations
 ---
 
-There is something special about `INCR`. Think about why Redis provides such an operation if we can do it ourselves with a bit of code? After all, it is as simple as:
+There is something special about `INCR`. You may wonder why Redis provides such an operation if we can do it ourselves with a bit of code? After all, it is as simple as:
 
     x = GET foo
     x = x + 1
@@ -92,7 +92,7 @@ Sorted Sets, which are kind of a more capable version of Sets, it is better
 to start introducing Sets first (which are a very useful data structure
 per se), and later Sorted Sets.
 
-There are more data types than just Lists. Redis also supports Sets, which are unsorted collections of elements. It is possible to add, remove, and test for existence of members, and perform the intersection between different Sets. Of course it is possible to get the elements of a set. Some examples will make it more clear. Keep in mind that `SADD` is the _add to set_ operation, `SREM` is the _remove from set_ operation, _sismember_ is the _test if member_ operation, and `SINTER` is the _perform intersection_ operation. Other operations are `SCARD` to get the cardinality (the number of elements) of a Set, and `SMEMBERS` to return all the members of a Set.
+There are more data types than just Lists. Redis also supports Sets, which are unsorted collections of elements. It is possible to add, remove, and test for existence of members, and perform the intersection between different Sets. Of course it is possible to get the elements of a Set. Some examples will make it more clear. Keep in mind that `SADD` is the _add to set_ operation, `SREM` is the _remove from set_ operation, _sismember_ is the _test if member_ operation, and `SINTER` is the _perform intersection_ operation. Other operations are `SCARD` to get the cardinality (the number of elements) of a Set, and `SMEMBERS` to return all the members of a Set.
 
     SADD myset a
     SADD myset b
@@ -108,7 +108,7 @@ Note that `SMEMBERS` does not return the elements in the same order we added the
     SADD mynewset hello
     SINTER myset mynewset => foo,b
 
-`SINTER` can return the intersection between Sets but it is not limited to two sets. You may ask for the intersection of 4,5, or 10000 Sets. Finally let's check how SISMEMBER works:
+`SINTER` can return the intersection between Sets but it is not limited to two Sets. You may ask for the intersection of 4,5, or 10000 Sets. Finally let's check how SISMEMBER works:
 
     SISMEMBER myset foo => 1
     SISMEMBER myset notamember => 0
@@ -118,7 +118,7 @@ The Sorted Set data type
 
 Sorted Sets are similar to Sets: collection of elements. However in Sorted
 Sets each element is associated with a floating point value, called the
-*element score*. Because of the score, elements inside a sorted set are
+*element score*. Because of the score, elements inside a Sorted Set are
 ordered, since we can always compare two elements by score (and if the score
 happens to be the same, we compare the two elements as strings).
 
@@ -171,7 +171,7 @@ Prerequisites
 
 If you haven't downloaded the [Retwis source code](https://github.com/antirez/retwis) already please grab it now. It contains a few PHP files, and also a copy of [Predis](https://github.com/nrk/predis), the PHP client library we use in this example.
 
-Another thing you probably want is a working Redis server. Just get the source, build with make, run with ./redis-server, and you're ready to go. No configuration is required at all in order to play with or run Retwis on your computer.
+Another thing you probably want is a working Redis server. Just get the source, build with `make`, run with `./redis-server`, and you're ready to go. No configuration is required at all in order to play with or run Retwis on your computer.
 
 Data layout
 ---
@@ -186,8 +186,8 @@ Let's start with Users. We need to represent users, of course, with their userna
 *Note: you should use a hashed password in a real application, for simplicity
 we store the password in clear text.*
 
-We use the `next_user_id` key in order to always get an unique ID for every new user. Then we use this unique ID to name the key holding a Hash with user's data. *This is a common design pattern* with key-values stores! Keep it in mind.
-Besides the fields already defined, we need some more stuff in order to fully define a User. For example, sometimes it can be useful to be able to get the user ID from the username, so every time we add an user, we also populate the `users` key, which is a Hash, with the username as field, and its ID as value.
+We use the `next_user_id` key in order to always get a unique ID for every new user. Then we use this unique ID to name the key holding a Hash with user's data. *This is a common design pattern* with key-values stores! Keep it in mind.
+Besides the fields already defined, we need some more stuff in order to fully define a User. For example, sometimes it can be useful to be able to get the user ID from the username, so every time we add a user, we also populate the `users` key, which is a Hash, with the username as field, and its ID as value.
 
     HSET users antirez 1000
 
@@ -220,12 +220,12 @@ Another important thing we need is a place were we can add the updates to displa
 
 This list is basically the User timeline. We'll push the IDs of her/his own
 posts, and, the IDs of all the posts of created by the following users.
-Basically we implement a write fanout.
+Basically, we'll implement a write fanout.
 
 Authentication
 ---
 
-OK, we have more or less everything about the user except for authentication. We'll handle authentication in a simple but robust way: we don't want to use PHP sessions, our system must be ready to be distributed among different web servers easily, so we'll keep the whole state in our Redis database. All we need is a random **unguessable** string to set as the cookie of an authenticated user, and a key that will contain the user ID of the client holding the string.
+OK, we have more or less everything about the user except for authentication. We'll handle authentication in a simple but robust way: we don't want to use PHP sessions, as our system must be ready to be distributed among different web servers easily, so we'll keep the whole state in our Redis database. All we need is a random **unguessable** string to set as the cookie of an authenticated user, and a key that will contain the user ID of the client holding the string.
 
 We need two things in order to make this thing work in a robust way.
 First: the current authentication *secret* (the random unguessable string)
@@ -240,12 +240,12 @@ authentication secrets to user IDs.
 
     HSET auths fea5e81ac8ca77622bed1c2132a021f9 1000
 
-In order to authenticate a user we'll do these simple steps ( see the `login.php` file in the Retwis source code):
+In order to authenticate a user we'll do these simple steps (see the `login.php` file in the Retwis source code):
 
- * Get the username and password via the login form
+ * Get the username and password via the login form.
  * Check if the `username` field actually exists in the `users` Hash.
- * If it exists we have the user id, (i.e. 1000)
- * Check if user:1000 password matches, if not, return an error message
+ * If it exists we have the user id, (i.e. 1000).
+ * Check if user:1000 password matches, if not, return an error message.
  * Ok authenticated! Set "fea5e81ac8ca77622bed1c2132a021f9" (the value of user:1000 `auth` field) as the "auth" cookie.
 
 This is the actual code:
@@ -274,7 +274,7 @@ This is the actual code:
 
 This happens every time a user logs in, but we also need a function `isLoggedIn` in order to check if a given user is already authenticated or not. These are the logical steps preformed by the `isLoggedIn` function:
 
- * Get the "auth" cookie from the user. If there is no cookie, the user is not logged in, of course. Let's call the value of the cookie `<authcookie>`
+ * Get the "auth" cookie from the user. If there is no cookie, the user is not logged in, of course. Let's call the value of the cookie `<authcookie>`.
  * Check if `<authcookie>` field in the `auths` Hash exists, and what the value (the user ID) is (1000 in the example).
  * In order for the system to be more robust, also verify that user:1000 auth field also matches.
  * OK the user is authenticated, and we loaded a bit of information in the $User global variable.
@@ -307,9 +307,9 @@ The code is simpler than the description, possibly:
         return true;
     }
 
-Having `loadUserInfo` as a separate function is overkill for our application, but it's a good approach in a complex application. The only thing that's missing from all the authentication is the logout. What do we do on logout? That's simple, we'll just change the random string in user:1000 `auth` field, remove the old authentication secret from the `auths` Hash., and add the new one.
+Having `loadUserInfo` as a separate function is overkill for our application, but it's a good approach in a complex application. The only thing that's missing from all the authentication is the logout. What do we do on logout? That's simple, we'll just change the random string in user:1000 `auth` field, remove the old authentication secret from the `auths` Hash, and add the new one.
 
-*Important:* the logout procedure explains why we don't just authenticate the user after looking up the authentication secret in the `auths` Hash, but double check it against user:1000 `auth` field. The true authentication string is the latter, while the `auths` Hash is just an authentication field that may even be volatile, or, if there are bugs in the program or a script gets interrupted, we may even end with multiple entries in the `auths` key pointing to the same user ID. The logout code is the following (logout.php):
+*Important:* the logout procedure explains why we don't just authenticate the user after looking up the authentication secret in the `auths` Hash, but double check it against user:1000 `auth` field. The true authentication string is the latter, while the `auths` Hash is just an authentication field that may even be volatile, or, if there are bugs in the program or a script gets interrupted, we may even end with multiple entries in the `auths` key pointing to the same user ID. The logout code is the following (`logout.php`):
 
     include("retwis.php");
 
@@ -339,7 +339,7 @@ Updates, also known as posts, are even simpler. In order to create a new post in
     INCR next_post_id => 10343
     HMSET post:10343 user_id $owner_id time $time body "I'm having fun with Retwis"
 
-As you can see each post is just represented by a Hash with three fields. The ID of the user owning the post, the time at which the post was published, and finally the body of the post, which is, the actual status message.
+As you can see each post is just represented by a Hash with three fields. The ID of the user owning the post, the time at which the post was published, and finally, the body of the post, which is, the actual status message.
 
 After we create a post and we obtain the post ID, we need to LPUSH the ID in the timeline of every user that is following the author of the post, and of course in the list of posts of the author itself (everybody is virtually following herself/himself). This is the file `post.php` that shows how this is performed:
 
@@ -371,7 +371,7 @@ The core of the function is the `foreach` loop. We use `ZRANGE` to get all the f
 
 Note that we also maintain a global timeline for all the posts, so that in the Retwis home page we can show everybody's updates easily. This requires just doing an `LPUSH` to the `timeline` List. Let's face it, aren't you starting to think it was a bit strange to have to sort things added in chronological order using `ORDER BY` with SQL? I think so.
 
-There is an interesting thing to notice in the code above: we use a new
+There is an interesting thing to notice in the code above: we used a new
 command called `LTRIM` after we perform the `LPUSH` operation in the global
 timeline. This is used in order to trim the list to just 1000 elements. The
 global timeline is actually only used in order to show a few posts in the
@@ -426,14 +426,14 @@ It is not hard, but we did not yet check how we create following / follower rela
         ZADD following:1000 5000
         ZADD followers:5000 1000
 
-Note the same pattern again and again. In theory with a relational database the list of following and followers would be contained in a single table with fields like `following_id` and `follower_id`. You can extract the followers or following of every user using an SQL query. With a key-value DB things are a bit different since we need to set both the `1000 is following 5000` and `5000 is followed by 1000` relations. This is the price to pay, but on the other hand accessing the data is simpler and extremely fast. Having these things as separate sets allows us to do interesting stuff. For example, using `ZINTERSTORE` we can have the intersection of 'following' of two different users, so we may add a feature to our Twitter clone so that it is able to tell you very quickly when you visit somebody else's profile, "you and Alice have 34 followers in common", and things like that.
+Note the same pattern again and again. In theory with a relational database, the list of following and followers would be contained in a single table with fields like `following_id` and `follower_id`. You can extract the followers or following of every user using an SQL query. With a key-value DB things are a bit different since we need to set both the `1000 is following 5000` and `5000 is followed by 1000` relations. This is the price to pay, but on the other hand accessing the data is simpler and extremely fast. Having these things as separate sets allows us to do interesting stuff. For example, using `ZINTERSTORE` we can have the intersection of 'following' of two different users, so we may add a feature to our Twitter clone so that it is able to tell you very quickly when you visit somebody else's profile, "you and Alice have 34 followers in common", and things like that.
 
 You can find the code that sets or removes a following / follower relation in the `follow.php` file.
 
 Making it horizontally scalable
 ---
 
-Gentle reader, if you reached this point you are already a hero. Thank you. Before talking about scaling horizontally it is worth checking performance on a single server. Retwis is *extremely fast*, without any kind of cache. On a very slow and loaded server, an Apache benchmark with 100 parallel clients issuing 100000 requests measured the average pageview to take 5 milliseconds. This means you can serve millions of users every day with just a single Linux box, and this one was monkey ass slow... Imagine the results with more recent hardware.
+Gentle reader, if you read till this point you are already a hero. Thank you. Before talking about scaling horizontally it is worth checking performance on a single server. Retwis is *extremely fast*, without any kind of cache. On a very slow and loaded server, an Apache benchmark with 100 parallel clients issuing 100000 requests measured the average pageview to take 5 milliseconds. This means you can serve millions of users every day with just a single Linux box, and this one was monkey ass slow... Imagine the results with more recent hardware.
 
 However you can't go with a single server forever, how do you scale a key-value
 store?
@@ -443,7 +443,7 @@ simple: you may use client-side sharding, or something like a sharding proxy
 like Twemproxy, or the upcoming Redis Cluster.
 
 To know more about those topics please read
-[our documentation about sharding](/topics/partitioning). However here the point
+[our documentation about sharding](/topics/partitioning). However, the point here
 to stress is that in a key-value store, if you design with care, the data set
 is split among **many independent small keys**. To distribute those keys
 to multiple nodes is more straightforward and predictable compared to using


### PR DESCRIPTION
facil.io includes an asynchronous [Redis client](https://github.com/boazsegev/facil.io/tree/master/lib/redis#getting-started-with-the-redis_engine) as well as a [RESP parser/formatter](https://github.com/boazsegev/facil.io/tree/master/lib/redis#the-resp-parser--formatter) that could be used as an independent module.

The parser and client were written from the ground up and are licensed under the MIT license.

This places fail.io in a unique position, the could provide an MIT licensing option where required. This is in contrast to most of the other clients, that are based on hiredis and require the BSD-3-clause license.

This might not be the fastest client or parser (it's more concerned with protecting itself from bad code than with being optimized), but it is (to the best of my knowledge) the only MIT licensed option.

Thanks! 👍🏻