### PR TITLE
Consolidate PR #836 and #837 into an updated branch

### DIFF
--- a/tools.json
+++ b/tools.json
@@ -599,6 +599,21 @@
     "authors": ["diguo58"]
   },
   {
+    "name": "facil.io",
+    "language": "C",
+    "url": "http://facil.io/",
+    "repository": "https://github.com/boazsegev/facil.io",
+    "description": "facil.io includes an asynchronous Redis client as well as a RESP parser/formatter that can be used independently. It's MIT licensed and doesn't use hiredis.",
+    "authors": ["bowildmusic"]
+  },
+  {
+    "name": "iodine",
+    "language": "Ruby",
+    "repository": "https://github.com/boazsegev/iodine",
+    "description": "Iodine is an HTTP / Websocket server with native pub/sub support. Iodine includes an integrated Redis client that provides Pub/Sub scaling beyond machine boundaries.",
+    "authors": ["bowildmusic"]
+  },
+  {
     "name": "Regis",
     "language": "Swift",
     "url": "https://www.harfangapps.com/regis/",


### PR DESCRIPTION
facil.io includes an asynchronous Redis client as well as a RESP
parser/formatter that could be used as an independent module.

The parser and client were written from the ground up and are licensed
under the MIT license.

This places fail.io in a unique position, the could provide an MIT
licensing option where required. This is in contrast to most of the
other clients, that are based on hiredis and require the BSD-3-clause
license.

This might not be the fastest client or parser (it's more concerned with
protecting itself from bad code than with being optimized), but it is
(to the best of my knowledge) the only MIT licensed option.

Thanks! 👍🏻

===

Iodine is a Ruby HTTP / Websocket server with native Pub/Sub (built
using the facil.io C framework).

Iodine includes an integrated Redis client that allows Pub/Sub to be
extended across machine boundaries (the native Pub/Sub is limited to the
process cluster).

Thanks! 🙏🏻