### PR TITLE
Documents the `MEMORY` command

### DIFF
--- a/commands.json
+++ b/commands.json
@@ -1534,6 +1534,50 @@
     "since": "1.0.0",
     "group": "list"
   },
+  "MEMORY DOCTOR": {
+    "summary": "Outputs memory problems report",
+    "since": "4.0.0",
+    "group": "server"
+  },
+  "MEMORY HELP": {
+    "summary": "Show helpful text about the different subcommands",
+    "since": "4.0.0",
+    "group": "server"
+
+  },
+  "MEMORY MALLOC-STATS": {
+    "summary": "Show allocator internal stats",
+    "since": "4.0.0",
+    "group": "server"
+  },
+  "MEMORY PURGE": {
+    "summary": "Ask the allocator to release memory",
+    "since": "4.0.0",
+    "group": "server"
+  },
+  "MEMORY STATS": {
+    "summary": "Show memory usage details",
+    "since": "4.0.0",
+    "group": "server"
+  },
+  "MEMORY USAGE": {
+    "summary": "Estimate the memory usage of a key",
+    "complexity": "O(N) where N is the number of samples.",
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key"
+      },
+      {
+        "command": "SAMPLES",
+        "name": "count",
+        "type": "integer",
+        "optional": true
+      }
+    ],
+    "since": "4.0.0",
+    "group": "server"
+  },
   "MGET": {
     "summary": "Get the values of all the given keys",
     "complexity": "O(N) where N is the number of keys to retrieve.",

--- a/commands/info.md
+++ b/commands/info.md
@@ -88,24 +88,30 @@ Here is the meaning of all fields in the **memory** section:
 *   `used_memory_rss_human`: Human readable representation of previous value
 *   `used_memory_peak`: Peak memory consumed by Redis (in bytes)
 *   `used_memory_peak_human`: Human readable representation of previous value
-*   `used_memory_peak_perc`: TBD
-*   `used_memory_overhead`: TBD
-*   `used_memory_startup`: TBD
-*   `used_memory_dataset`: TBD
-*   `used_memory_dataset_perc`: TBD
-*   `total_system_memory`: TBD
+*   `used_memory_peak_perc`: The percentage of `used_memory_peak` out of
+     `used_memory`
+*   `used_memory_overhead`: The sum in bytes of all overheads that the server
+     allocated for managing its internal data structures
+*   `used_memory_startup`: Initial amount of memory consumed by Redis at startup
+     in bytes
+*   `used_memory_dataset`: The size in bytes of the dataset
+     (`used_memory_overhead` subtracted from `used_memory`)
+*   `used_memory_dataset_perc`: The percentage of `used_memory_dataset` out of
+     the net memory usage (`used_memory` minus `used_memory_startup`)
+*   `total_system_memory`: The total amount of memory that the Redis host has
 *   `total_system_memory_human`: Human readable representation of previous value
 *   `used_memory_lua`: Number of bytes used by the Lua engine
 *   `used_memory_lua_human`: Human readable representation of previous value
-*   `used_memory_lua:`: TBD
-*   `used_memory_lua_human`: Human readable representation of previous value
-*   `maxmemory`: TBD
+*   `maxmemory`: The value of the `maxmemory` configuration directive
 *   `maxmemory_human`: Human readable representation of previous value
-*   `maxmemory_policy`: TBD
+*   `maxmemory_policy`: The value of the `maxmemory-policy` configuration
+     directive
 *   `mem_fragmentation_ratio`: Ratio between `used_memory_rss` and `used_memory`
 *   `mem_allocator`: Memory allocator, chosen at compile time
-*   `active_defrag_running`: TBD
-*   `lazyfree_pending_objects`: TBD
+*   `active_defrag_running`: Flag indicating if active defragmentation is active
+*   `lazyfree_pending_objects`: The number of objects waiting to be freed (as a
+     result of calling `UNLINK`, or `FLUSHDB` and `FLUSHALL` with the **ASYNC**
+     option)
 
 Ideally, the `used_memory_rss` value should be only slightly higher than
 `used_memory`.
@@ -126,6 +132,9 @@ reported by the operating system. It may be due to the fact memory has been
 used and released by Redis, but not given back to the system. The 
 `used_memory_peak` value is generally useful to check this point.
 
+Additional introspective information about the server's memory can be obtained
+by referring to the `MEMORY STATS` command and the `MEMORY DOCTOR`.
+
 Here is the meaning of all fields in the **persistence** section:
 
 *   `loading`: Flag indicating if the load of a dump file is on-going
@@ -137,7 +146,8 @@ Here is the meaning of all fields in the **persistence** section:
      seconds
 *   `rdb_current_bgsave_time_sec`: Duration of the on-going RDB save operation
      if any
-*   `rdb_last_cow_size`: TBD
+*   `rdb_last_cow_size`: The size in bytes of copy-on-write allocations during
+     the last RBD save operation
 *   `aof_enabled`: Flag indicating AOF logging is activated
 *   `aof_rewrite_in_progress`: Flag indicating a AOF rewrite operation is
      on-going
@@ -148,8 +158,9 @@ Here is the meaning of all fields in the **persistence** section:
 *   `aof_current_rewrite_time_sec`: Duration of the on-going AOF rewrite
      operation if any
 *   `aof_last_bgrewrite_status`: Status of the last AOF rewrite operation
-*   `aof_last_write_status`: TBD
-*   `aof_last_cow_size`: TBD
+*   `aof_last_write_status`: Status of the last write operation to the AOF
+*   `aof_last_cow_size`: The size in bytes of copy-on-write allocations during
+     the last AOF rewrite operation
 
 `changes_since_last_save` refers to the number of operations that produced
 some kind of changes in the dataset since the last time either `SAVE` or
@@ -182,15 +193,15 @@ Here is the meaning of all fields in the **stats** section:
      server
 *   `total_commands_processed`: Total number of commands processed by the server
 *   `instantaneous_ops_per_sec`: Number of commands processed per second
-*   `total_net_input_bytes`: TBD
-*   `total_net_output_bytes`: TBD
-*   `instantaneous_input_kbps`: TBD
-*   `instantaneous_output_kbps`: TBD
+*   `total_net_input_bytes`: The total number of bytes read from the network
+*   `total_net_output_bytes`: The total number of bytes written to the network
+*   `instantaneous_input_kbps`: The network's read rate per second in KB/sec
+*   `instantaneous_output_kbps`: The network's write rate per second in KB/sec
 *   `rejected_connections`: Number of connections rejected because of
      `maxclients` limit
-*   `sync_full`: TBD
-*   `sync_partial_ok`: TBD
-*   `sync_partial_err`: TBD
+*   `sync_full`: The number of full resyncs with slaves
+*   `sync_partial_ok`: The number of accpepted partial resync requests
+*   `sync_partial_err`: The number of denied partial resync requests
 *   `expired_keys`: Total number of key expiration events
 *   `evicted_keys`: Number of evicted keys due to `maxmemory` limit
 *   `keyspace_hits`: Number of successful lookup of keys in the main dictionary
@@ -200,26 +211,33 @@ Here is the meaning of all fields in the **stats** section:
 *   `pubsub_patterns`: Global number of pub/sub pattern with client
      subscriptions
 *   `latest_fork_usec`: Duration of the latest fork operation in microseconds
-*   `migrate_cached_sockets`: TBD
-*   `slave_expires_tracked_keys`: TBD
-*   `active_defrag_hits`: TBD
-*   `active_defrag_misses`: TBD
-*   `active_defrag_key_hits`: TBD
-*   `active_defrag_key_misses`: TBD
+*   `migrate_cached_sockets`: The number of sockets open for `MIGRATE` purposes
+*   `slave_expires_tracked_keys`: The number of keys tracked for expiry purposes
+     (applicable only to writable slaves)
+*   `active_defrag_hits`: Number of value reallocations performed by active the
+     defragmentation process
+*   `active_defrag_misses`: Number of aborted value reallocations started by the
+     active defragmentation process
+*   `active_defrag_key_hits`: Number of keys that were actively defragmented
+*   `active_defrag_key_misses`: Number of keys that were skipped by the active
+     defragmentation process
 
 Here is the meaning of all fields in the **replication** section:
 
 *   `role`: Value is "master" if the instance is slave of no one, or "slave" if
      the instance is enslaved to master.
      Note that a slave can be master of another slave (daisy chaining).
-*   `master_replid`: TBD
-*   `master_replid2`: TBD
-*   `master_repl_offset`: TBD
-*   `second_repl_offset`: TBD
-*   `repl_backlog_active`: TBD
-*   `repl_backlog_size`: Size in bytes of the replication backlog
-*   `repl_backlog_first_byte_offset`: TBD
-*   `repl_backlog_histlen`: TBD
+*   `master_replid`: The replication ID of the Redis server, if it is a master
+*   `master_replid2`: The repliation ID of the Redis server's master, if it is
+     enslaved
+*   `master_repl_offset`: The server's current replication offset
+*   `second_repl_offset`: The offset up to which replication IDs are accepted
+*   `repl_backlog_active`: Flag indicating replication backlog is active
+*   `repl_backlog_size`: Total size in bytes of the replication backlog buffer
+*   `repl_backlog_first_byte_offset`: The master offset of the replication
+     backlog buffer
+*   `repl_backlog_histlen`: Size in bytes of the data in the replication backlog
+     buffer
 
 If the instance is a slave, these additional fields are provided:
 
@@ -229,9 +247,9 @@ If the instance is a slave, these additional fields are provided:
 *   `master_last_io_seconds_ago`: Number of seconds since the last interaction
      with master
 *   `master_sync_in_progress`: Indicate the master is syncing to the slave
-*   `slave_repl_offset`: TBD
-*   `slave_priority`: TBD
-*   `slave_read_only`: TBD
+*   `slave_repl_offset`: The replication offset of the slave instance
+*   `slave_priority`: The priority of the instance as a candidate for failover
+*   `slave_read_only`: Flag indicating if the slave is read-only
 
 If a SYNC operation is on-going, these additional fields are provided:
 

--- a/commands/info.md
+++ b/commands/info.md
@@ -47,44 +47,73 @@ Here is the meaning of all fields in the **server** section:
 *   `redis_version`: Version of the Redis server
 *   `redis_git_sha1`:  Git SHA1
 *   `redis_git_dirty`: Git dirty flag
+*   `redis_build_id`: The build id
+*   `redis_mode`: The server's mode ("standalone", "sentinel" or "cluster")
 *   `os`: Operating system hosting the Redis server
 *   `arch_bits`: Architecture (32 or 64 bits)
-*   `multiplexing_api`: event loop mechanism used by Redis
+*   `multiplexing_api`: Event loop mechanism used by Redis
+*   `atomicvar_api`: Atomicvar API used by Redis
 *   `gcc_version`: Version of the GCC compiler used to compile the Redis server
 *   `process_id`: PID of the server process
-*   `run_id`: Random value identifying the Redis server (to be used by Sentinel and Cluster)
+*   `run_id`: Random value identifying the Redis server (to be used by Sentinel
+     and Cluster)
 *   `tcp_port`: TCP/IP listen port
 *   `uptime_in_seconds`: Number of seconds since Redis server start
 *   `uptime_in_days`: Same value expressed in days
+*   `hz`: The server's frequency setting
 *   `lru_clock`: Clock incrementing every minute, for LRU management
+*   `executable`: The path to the server's executable
+*   `config_file`: The path to the config file
 
 Here is the meaning of all fields in the **clients** section:
 
-*   `connected_clients`: Number of client connections (excluding connections from slaves)
-*   `client_longest_output_list`: longest output list among current client connections
-*   `client_biggest_input_buf`: biggest input buffer among current client connections
-*   `blocked_clients`: Number of clients pending on a blocking call (BLPOP, BRPOP, BRPOPLPUSH)
+*   `connected_clients`: Number of client connections (excluding connections
+     from slaves)
+*   `client_longest_output_list`: longest output list among current client
+     connections
+*   `client_biggest_input_buf`: biggest input buffer among current client
+     connections
+*   `blocked_clients`: Number of clients pending on a blocking call (BLPOP, 
+     BRPOP, BRPOPLPUSH)
 
 Here is the meaning of all fields in the **memory** section:
 
-*   `used_memory`:  total number of bytes allocated by Redis using its
-     allocator (either standard **libc**, **jemalloc**, or an alternative allocator such
-     as [**tcmalloc**][hcgcpgp]
+*   `used_memory`: Total number of bytes allocated by Redis using its
+     allocator (either standard **libc**, **jemalloc**, or an alternative
+     allocator such as [**tcmalloc**][hcgcpgp])
 *   `used_memory_human`: Human readable representation of previous value
 *   `used_memory_rss`: Number of bytes that Redis allocated as seen by the
-     operating system (a.k.a resident set size). This is the number reported by tools
-     such as `top(1)` and `ps(1)`
+     operating system (a.k.a resident set size). This is the number reported by
+     tools such as `top(1)` and `ps(1)`
+*   `used_memory_rss_human`: Human readable representation of previous value
 *   `used_memory_peak`: Peak memory consumed by Redis (in bytes)
 *   `used_memory_peak_human`: Human readable representation of previous value
+*   `used_memory_peak_perc`: TBD
+*   `used_memory_overhead`: TBD
+*   `used_memory_startup`: TBD
+*   `used_memory_dataset`: TBD
+*   `used_memory_dataset_perc`: TBD
+*   `total_system_memory`: TBD
+*   `total_system_memory_human`: Human readable representation of previous value
 *   `used_memory_lua`: Number of bytes used by the Lua engine
+*   `used_memory_lua_human`: Human readable representation of previous value
+*   `used_memory_lua:`: TBD
+*   `used_memory_lua_human`: Human readable representation of previous value
+*   `maxmemory`: TBD
+*   `maxmemory_human`: Human readable representation of previous value
+*   `maxmemory_policy`: TBD
 *   `mem_fragmentation_ratio`: Ratio between `used_memory_rss` and `used_memory`
 *   `mem_allocator`: Memory allocator, chosen at compile time
+*   `active_defrag_running`: TBD
+*   `lazyfree_pending_objects`: TBD
 
-Ideally, the `used_memory_rss` value should be only slightly higher than `used_memory`.
+Ideally, the `used_memory_rss` value should be only slightly higher than
+`used_memory`.
 When rss >> used, a large difference means there is memory fragmentation
-(internal or external), which can be evaluated by checking `mem_fragmentation_ratio`.
-When used >> rss, it means part of Redis memory has been swapped off by the operating
-system: expect some significant latencies.
+(internal or external), which can be evaluated by checking
+`mem_fragmentation_ratio`.
+When used >> rss, it means part of Redis memory has been swapped off by the
+operating system: expect some significant latencies.
 
 Because Redis does not have control over how its allocations are mapped to
 memory pages, high `used_memory_rss` is often the result of a spike in memory
@@ -94,8 +123,8 @@ When Redis frees memory, the memory is given back to the allocator, and the
 allocator may or may not give the memory back to the system. There may be
 a discrepancy between the `used_memory` value and memory consumption as
 reported by the operating system. It may be due to the fact memory has been
-used and released by Redis, but not given back to the system. The `used_memory_peak`
-value is generally useful to check this point.
+used and released by Redis, but not given back to the system. The 
+`used_memory_peak` value is generally useful to check this point.
 
 Here is the meaning of all fields in the **persistence** section:
 
@@ -104,15 +133,23 @@ Here is the meaning of all fields in the **persistence** section:
 *   `rdb_bgsave_in_progress`: Flag indicating a RDB save is on-going
 *   `rdb_last_save_time`: Epoch-based timestamp of last successful RDB save
 *   `rdb_last_bgsave_status`: Status of the last RDB save operation
-*   `rdb_last_bgsave_time_sec`: Duration of the last RDB save operation in seconds
-*   `rdb_current_bgsave_time_sec`: Duration of the on-going RDB save operation if any
+*   `rdb_last_bgsave_time_sec`: Duration of the last RDB save operation in
+     seconds
+*   `rdb_current_bgsave_time_sec`: Duration of the on-going RDB save operation
+     if any
+*   `rdb_last_cow_size`: TBD
 *   `aof_enabled`: Flag indicating AOF logging is activated
-*   `aof_rewrite_in_progress`: Flag indicating a AOF rewrite operation is on-going
+*   `aof_rewrite_in_progress`: Flag indicating a AOF rewrite operation is
+     on-going
 *   `aof_rewrite_scheduled`: Flag indicating an AOF rewrite operation
      will be scheduled once the on-going RDB save is complete.
-*   `aof_last_rewrite_time_sec`: Duration of the last AOF rewrite operation in seconds
-*   `aof_current_rewrite_time_sec`: Duration of the on-going AOF rewrite operation if any
+*   `aof_last_rewrite_time_sec`: Duration of the last AOF rewrite operation in
+     seconds
+*   `aof_current_rewrite_time_sec`: Duration of the on-going AOF rewrite
+     operation if any
 *   `aof_last_bgrewrite_status`: Status of the last AOF rewrite operation
+*   `aof_last_write_status`: TBD
+*   `aof_last_cow_size`: TBD
 
 `changes_since_last_save` refers to the number of operations that produced
 some kind of changes in the dataset since the last time either `SAVE` or
@@ -126,12 +163,14 @@ If AOF is activated, these additional fields will be added:
      will be scheduled once the on-going RDB save is complete.
 *   `aof_buffer_length`: Size of the AOF buffer
 *   `aof_rewrite_buffer_length`: Size of the AOF rewrite buffer
-*   `aof_pending_bio_fsync`: Number of fsync pending jobs in background I/O queue
+*   `aof_pending_bio_fsync`: Number of fsync pending jobs in background I/O
+     queue
 *   `aof_delayed_fsync`: Delayed fsync counter
 
 If a load operation is on-going, these additional fields will be added:
 
-*   `loading_start_time`: Epoch-based timestamp of the start of the load operation
+*   `loading_start_time`: Epoch-based timestamp of the start of the load
+     operation
 *   `loading_total_bytes`: Total file size
 *   `loading_loaded_bytes`: Number of bytes already loaded
 *   `loading_loaded_perc`: Same value expressed as a percentage
@@ -139,35 +178,66 @@ If a load operation is on-going, these additional fields will be added:
 
 Here is the meaning of all fields in the **stats** section:
 
-*   `total_connections_received`: Total number of connections accepted by the server
+*   `total_connections_received`: Total number of connections accepted by the
+     server
 *   `total_commands_processed`: Total number of commands processed by the server
 *   `instantaneous_ops_per_sec`: Number of commands processed per second
-*   `rejected_connections`: Number of connections rejected because of `maxclients` limit
+*   `total_net_input_bytes`: TBD
+*   `total_net_output_bytes`: TBD
+*   `instantaneous_input_kbps`: TBD
+*   `instantaneous_output_kbps`: TBD
+*   `rejected_connections`: Number of connections rejected because of
+     `maxclients` limit
+*   `sync_full`: TBD
+*   `sync_partial_ok`: TBD
+*   `sync_partial_err`: TBD
 *   `expired_keys`: Total number of key expiration events
 *   `evicted_keys`: Number of evicted keys due to `maxmemory` limit
 *   `keyspace_hits`: Number of successful lookup of keys in the main dictionary
 *   `keyspace_misses`: Number of failed lookup of keys in the main dictionary
-*   `pubsub_channels`: Global number of pub/sub channels with client subscriptions
-*   `pubsub_patterns`: Global number of pub/sub pattern with client subscriptions
+*   `pubsub_channels`: Global number of pub/sub channels with client
+     subscriptions
+*   `pubsub_patterns`: Global number of pub/sub pattern with client
+     subscriptions
 *   `latest_fork_usec`: Duration of the latest fork operation in microseconds
+*   `migrate_cached_sockets`: TBD
+*   `slave_expires_tracked_keys`: TBD
+*   `active_defrag_hits`: TBD
+*   `active_defrag_misses`: TBD
+*   `active_defrag_key_hits`: TBD
+*   `active_defrag_key_misses`: TBD
 
 Here is the meaning of all fields in the **replication** section:
 
-*   `role`: Value is "master" if the instance is slave of no one, or "slave" if the instance is enslaved to a master.
-    Note that a slave can be master of another slave (daisy chaining).
+*   `role`: Value is "master" if the instance is slave of no one, or "slave" if
+     the instance is enslaved to master.
+     Note that a slave can be master of another slave (daisy chaining).
+*   `master_replid`: TBD
+*   `master_replid2`: TBD
+*   `master_repl_offset`: TBD
+*   `second_repl_offset`: TBD
+*   `repl_backlog_active`: TBD
+*   `repl_backlog_size`: Size in bytes of the replication backlog
+*   `repl_backlog_first_byte_offset`: TBD
+*   `repl_backlog_histlen`: TBD
 
 If the instance is a slave, these additional fields are provided:
 
 *   `master_host`: Host or IP address of the master
 *   `master_port`: Master listening TCP port
 *   `master_link_status`: Status of the link (up/down)
-*   `master_last_io_seconds_ago`: Number of seconds since the last interaction with master
+*   `master_last_io_seconds_ago`: Number of seconds since the last interaction
+     with master
 *   `master_sync_in_progress`: Indicate the master is syncing to the slave
+*   `slave_repl_offset`: TBD
+*   `slave_priority`: TBD
+*   `slave_read_only`: TBD
 
 If a SYNC operation is on-going, these additional fields are provided:
 
 *   `master_sync_left_bytes`: Number of bytes left before syncing is complete
-*   `master_sync_last_io_seconds_ago`: Number of seconds since last transfer I/O during a SYNC operation
+*   `master_sync_last_io_seconds_ago`: Number of seconds since last transfer I/O
+     during a SYNC operation
 
 If the link between master and slave is down, an additional field is provided:
 
@@ -177,9 +247,14 @@ The following field is always provided:
 
 *   `connected_slaves`: Number of connected slaves
 
+If the server is configured with the `min-slaves-to-write` directive, an
+additional field is provided:
+
+*   `min_slaves_good_slaves`: Number of slaves currently considered good 
+
 For each slave, the following line is added:
 
-*   `slaveXXX`: id, IP address, port, state
+*   `slaveXXX`: id, IP address, port, state, offset, lag
 
 Here is the meaning of all fields in the **cpu** section:
 
@@ -200,7 +275,8 @@ The **cluster** section currently only contains a unique field:
 
 *   `cluster_enabled`: Indicate Redis cluster is enabled
 
-The **keyspace** section provides statistics on the main dictionary of each database.
+The **keyspace** section provides statistics on the main dictionary of each
+database.
 The statistics are the number of keys, and the number of keys with an expiration.
 
 For each database, the following line is added:

--- a/commands/info.md
+++ b/commands/info.md
@@ -200,7 +200,7 @@ Here is the meaning of all fields in the **stats** section:
 *   `rejected_connections`: Number of connections rejected because of
      `maxclients` limit
 *   `sync_full`: The number of full resyncs with slaves
-*   `sync_partial_ok`: The number of accpepted partial resync requests
+*   `sync_partial_ok`: The number of accepted partial resync requests
 *   `sync_partial_err`: The number of denied partial resync requests
 *   `expired_keys`: Total number of key expiration events
 *   `evicted_keys`: Number of evicted keys due to `maxmemory` limit

--- a/commands/memory-doctor.md
+++ b/commands/memory-doctor.md
@@ -1,0 +1,6 @@
+The `MEMORY DOCTOR` command reports about different memory-related issues that
+the Redis server experiences, and advises about possible remedies.
+
+@return
+
+@bulk-string-reply 

--- a/commands/memory-help.md
+++ b/commands/memory-help.md
@@ -1,0 +1,6 @@
+The `MEMORY HELP` command returns a helpful text describing the different
+subcommands.
+
+@return
+
+@array-reply: a list of subcommands and their descriptions

--- a/commands/memory-malloc-stats.md
+++ b/commands/memory-malloc-stats.md
@@ -1,0 +1,9 @@
+The `MEMORY MALLOC-STATS` command provides an internal statistics report from
+the memory allocator.
+
+This command is currently implemented only when using **jemalloc** as an
+allocator, and evaluates to a benign NOOP for all others.
+
+@return
+
+@bulk-string-reply: the memory allocator's internal statistics report

--- a/commands/memory-purge.md
+++ b/commands/memory-purge.md
@@ -1,0 +1,9 @@
+The `MEMORY PURGE` command attempts to purge dirty pages so these can be
+reclaimed by the allocator.
+
+This command is currently implemented only when using **jemalloc** as an
+allocator, and evaluates to a benign NOOP for all others.
+
+@return
+
+@simple-string-reply

--- a/commands/memory-stats.md
+++ b/commands/memory-stats.md
@@ -1,0 +1,43 @@
+The `MEMORY STATS` command returns an @array-reply about the memory usage of the
+server.
+
+The information about memory usage is provided as metrics and their respective
+values. The following metrics are reported:
+
+*   `peak.allocated`: Peak memory consumed by Redis in bytes (see `INFO`'s
+     `used_memory`)
+*   `total.allocated`: Total number of bytes allocated by Redis using its
+     allocator (see `INFO`'s `used_memory`)
+*   `startup.allocated`: Initial amount of memory consumed by Redis at startup
+     in bytes
+*   `replication.backlog`: Size in bytes of the replication backlog (see
+     `INFO`'s `repl_backlog_size`)
+*   `clients.slaves`: The total size in bytes of all slaves overheads (output
+     and query buffers, connection contexts)
+*   `clients.normal`: The total size in bytes of all clients overheads (output
+     and query buffers, connection contexts)
+*   `aof.buffer`: The summed size in bytes of the current and rewrite AOF
+     buffers (see `INFO`'s `aof_buffer_length` and `aof_rewrite_buffer_length`,
+     respectively)
+*   `dbXXX`: For each of the server's databases, the overheads of the main and
+     expiry dictionaries (`overhead.hashtable.main` and
+    `overhead.hashtable.expires`, respectively) are reported in bytes
+*   `overhead.total`: The sum of all overheads, i.e. `startup.allocated`,
+     `replication.backlog`, `clients.slaves`, `clients.normal`, `aof.buffer` and
+     those of the internal data structures that are used in managing the
+     Redis keyspace
+*   `keys.count`: The total number of keys stored across all databases in the
+     server
+*   `keys.bytes-per-key`: The ratio between **net memory usage** (`total.allocated`
+     minus `startup.allocated`) and `keys.count` 
+*   `dataset.bytes`: The size in bytes of the dataset (`overhead.total`
+     subtracted from `total.allocated`)
+*   `dataset.percentage`: The percentage of `dataset.bytes` out of the net
+     memory usage
+*   `peak.percentage`: The percentage of `peak.allocated` out of
+     `total.allocated`
+*   `fragmentation`: See `INFO`'s `mem_fragmentation_ratio`
+
+@return
+
+@array-reply: nested list of memory usage metrics and their values

--- a/commands/memory-stats.md
+++ b/commands/memory-stats.md
@@ -9,7 +9,7 @@ values. The following metrics are reported:
 *   `total.allocated`: Total number of bytes allocated by Redis using its
      allocator (see `INFO`'s `used_memory`)
 *   `startup.allocated`: Initial amount of memory consumed by Redis at startup
-     in bytes
+     in bytes (see `INFO`'s `used_memory_startup`)
 *   `replication.backlog`: Size in bytes of the replication backlog (see
      `INFO`'s `repl_backlog_size`)
 *   `clients.slaves`: The total size in bytes of all slaves overheads (output
@@ -25,13 +25,13 @@ values. The following metrics are reported:
 *   `overhead.total`: The sum of all overheads, i.e. `startup.allocated`,
      `replication.backlog`, `clients.slaves`, `clients.normal`, `aof.buffer` and
      those of the internal data structures that are used in managing the
-     Redis keyspace
+     Redis keyspace (see `INFO`'s `used_memory_overhead`)
 *   `keys.count`: The total number of keys stored across all databases in the
      server
 *   `keys.bytes-per-key`: The ratio between **net memory usage** (`total.allocated`
      minus `startup.allocated`) and `keys.count` 
-*   `dataset.bytes`: The size in bytes of the dataset (`overhead.total`
-     subtracted from `total.allocated`)
+*   `dataset.bytes`: The size in bytes of the dataset, i.e. `overhead.total`
+     subtracted from `total.allocated` (see `INFO`'s `used_memory_dataset`)
 *   `dataset.percentage`: The percentage of `dataset.bytes` out of the net
      memory usage
 *   `peak.percentage`: The percentage of `peak.allocated` out of

--- a/commands/memory-usage.md
+++ b/commands/memory-usage.md
@@ -1,0 +1,40 @@
+The `MEMORY USAGE` command reports the number of bytes that a key and its value
+require to be stored in RAM.
+
+The reported usage is the total of memory allocations for data and
+administrative overheads that a key its value require.
+
+For nested data types, the optional `SAMPLES` option can be provided, where
+`count` is the number of sampled nested values. By default, this option is set
+to `5`. To sample the all of the nested values, use `SAMPLES 0`. 
+
+@examples
+
+With Redis v4.0.1 64-bit and **jemalloc**, the empty string measures as follows:
+
+```
+> SET "" ""
+OK
+> MEMORY USAGE ""
+(integer) 51
+```
+
+These bytes are pure overhead at the moment as no actual data is stored, and are
+used for maintaining the internal data structures of the server. Longer keys and
+values show asymptotically linear usage.
+
+```
+> SET foo bar
+OK
+> MEMORY USAGE foo
+(integer) 54
+> SET cento 01234567890123456789012345678901234567890123
+45678901234567890123456789012345678901234567890123456789
+OK
+127.0.0.1:6379> MEMORY USAGE cento
+(integer) 153
+```
+
+@return
+
+@integer-reply: the memory usage in bytes 


### PR DESCRIPTION
A stab a documenting v4's `MEMORY` command /cc @antirez 

Additionally, as part of this effort it would be good to update `INFO`'s page - ~currently marked as a WIP commit~ requires an expert review for correctness.

TODO:
1. Use this opportunity to document active defragmentation as well 

Additional ponderings:

1. Is 'server' the right group or is a new one needed
2. Should 'memory help' be documented (ATM yes), but also applies to 'debug help' etc
3. Speaking of debug, there's quite a few subcommands missing from the docs. Should they be documented? They're temporary but temporary things tend to last forever...
4. I see that that redis/unstable has 'memory doctor' in the help, whereas 4.0 doesn't although it is supported by the server - is that intentional or an omission (i.e. PR to antirez/redis)?
5. Should `memory` be enabled in the website's interactive mode?
6. `MEMORY USAGE` and the modules API - should the connection to ModuleMemoryUsageFunc be mentioned, perhaps as a note or some templatized "@module-api" kind of thing across the corpus?
7. Some of the docs/commands are `jemalloc` specific - perhaps a way to templatize/organize this can be added