### PR TITLE
add redis-rating to modules.json

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -196,5 +196,14 @@
       "RedBeardLab"
     ],
     "stars": 613
+  },
+
+  {
+    "name": "redis-rating",
+    "license" : "MIT",
+    "repository": "https://github.com/poga/redis-rating",
+    "description": "Estimate actual rating from postive/negative ratings",
+    "authors": ["devpoga"],
+    "stars": 14
   }
 ]


### PR DESCRIPTION
`redis-rating` is a Redis module for estimating actual rating from positive/negative ratings.