### PR TITLE
add docs for fetching entire list

### DIFF
--- a/commands/lrange.md
+++ b/commands/lrange.md
@@ -23,6 +23,9 @@ If `start` is larger than the end of the list, an empty list is returned.
 If `stop` is larger than the actual end of the list, Redis will treat it like
 the last element of the list.
 
+We can fetch the entire list by passing a range of 0 for the start index and -1
+for the last index.
+
 @return
 
 @array-reply: list of elements in the specified range.


### PR DESCRIPTION
it wasn't clear in the example here: https://redis.io/commands/lrem why it fetches all remaining items. 

found the docs for that here https://redislabs.com/ebook/part-1-getting-started/chapter-1-getting-to-know-redis/1-2-what-redis-data-structures-look-like/1-2-2-lists-in-redis/

<img width="776" alt="redis-fetch-entire-list" src="https://user-images.githubusercontent.com/13506154/29922300-510702ce-8e55-11e7-9aed-813bd326d687.png">
