### PR TITLE
changed acl-redis library's link

### DIFF
--- a/clients.json
+++ b/clients.json
@@ -824,8 +824,6 @@
   },
 
   {
-<<<<<<< HEAD
-=======
     "name": "async-redis",
     "language": "C++",
     "url": "https://github.com/hamidr/async-redis",
@@ -836,16 +834,11 @@
   },
 
   {
->>>>>>> a714bd261aa26e3930a4a53384f2fe7bda1c8f2b
     "name": "acl-redis",
     "language": "C++",
     "url": "https://github.com/zhengshuxin/acl/tree/master/lib_acl_cpp/samples/redis",
     "repository": "https://github.com/zhengshuxin/acl/tree/master/lib_acl_cpp/include/acl_cpp/redis",
-<<<<<<< HEAD
-    "description": "Stantard C++ redis client with high performance and stl-like interface, supporting redis cluster with multi-threads-safely",
-=======
     "description": "Standard C++ Redis Client with high performance and stl-like interface, supporting Redis Cluster, thread-safe",
->>>>>>> a714bd261aa26e3930a4a53384f2fe7bda1c8f2b
     "authors": ["zhengshuxin"],
     "active": true
   },

--- a/clients.json
+++ b/clients.json
@@ -836,9 +836,9 @@
   {
     "name": "acl-redis",
     "language": "C++",
-    "url": "https://github.com/zhengshuxin/acl/tree/master/lib_acl_cpp/samples/redis",
-    "repository": "https://github.com/zhengshuxin/acl/tree/master/lib_acl_cpp/include/acl_cpp/redis",
-    "description": "Standard C++ Redis Client with high performance and stl-like interface, supporting Redis Cluster, thread-safe",
+    "url": "https://github.com/acl-dev/acl/tree/master/lib_acl_cpp/samples/redis",
+    "repository": "https://github.com/acl-dev/acl/tree/master/lib_acl_cpp/include/acl_cpp/redis",
+    "description": "Standard C++ Redis Client with high performance and stl-like interface, supporting Redis Cluster, thread safety",
     "authors": ["zhengshuxin"],
     "active": true
   },

--- a/clients.json
+++ b/clients.json
@@ -818,8 +818,8 @@
     "language": "C++",
     "url": "https://github.com/zhengshuxin/acl/tree/master/lib_acl_cpp/samples/redis",
     "repository": "https://github.com/zhengshuxin/acl/tree/master/lib_acl_cpp/include/acl_cpp/redis",
-    "description": "Full Redis client commands, one redis command, one redis function",
-    "authors": [],
+    "description": "Implement fully redis commands with different C++ classes like STL, supporting redis-server in cluster or single mode",
+    "authors": [zhengshuxin],
     "active": true
   },
 

--- a/clients.json
+++ b/clients.json
@@ -814,12 +814,12 @@
   },
 
   {
-    "name": "redis-client for C++",
+    "name": "acl-redis",
     "language": "C++",
     "url": "https://github.com/zhengshuxin/acl/tree/master/lib_acl_cpp/samples/redis",
     "repository": "https://github.com/zhengshuxin/acl/tree/master/lib_acl_cpp/include/acl_cpp/redis",
-    "description": "Implement fully redis commands with different C++ classes like STL, supporting redis-server in cluster or single mode",
-    "authors": [zhengshuxin],
+    "description": "Stantard C++ redis client with high performance and stl-like interface, supporting redis cluster with multi-threads-safely",
+    "authors": ["zhengshuxin"],
     "active": true
   },
 


### PR DESCRIPTION
changed acl-redis library's link:
https://github.com/acl-dev/acl/tree/master/lib_acl_cpp/samples/redis
https://github.com/acl-dev/acl/tree/master/lib_acl_cpp/include/acl_cpp/redis