### PR TITLE
Fix a Small Typo

### DIFF
--- a/topics/data-types-intro.md
+++ b/topics/data-types-intro.md
@@ -327,7 +327,7 @@ pop. If we try to pop yet another element, this is the result we get:
     > rpop mylist
     (nil)
 
-Redis returned a NULL value to signal that there are no elements into the
+Redis returned a NULL value to signal that there are no elements in the
 list.
 
 Common use cases for lists


### PR DESCRIPTION
`no elements into the list` -> `no elements in the list`