### PR TITLE
Don't say "simply"

### DIFF
--- a/commands.json
+++ b/commands.json
@@ -629,7 +629,7 @@
   },
   "DUMP": {
     "summary": "Return a serialized version of the value stored at the specified key.",
-    "complexity": "O(1) to access the key and additional O(N*M) to serialized it, where N is the number of Redis objects composing the value and M their average size. For small string values the time complexity is thus O(1)+O(1*M) where M is small, so simply O(1).",
+    "complexity": "O(1) to access the key and additional O(N*M) to serialized it, where N is the number of Redis objects composing the value and M their average size. For small string values the time complexity is thus O(1)+O(1*M) where M is small, so O(1).",
     "arguments": [
       {
         "name": "key",
@@ -1918,7 +1918,7 @@
   },
   "RESTORE": {
     "summary": "Create a key using the provided serialized value, previously obtained using DUMP.",
-    "complexity": "O(1) to create the new key and additional O(N*M) to reconstruct the serialized value, where N is the number of Redis objects composing the value and M their average size. For small string values the time complexity is thus O(1)+O(1*M) where M is small, so simply O(1). However for sorted set values the complexity is O(N*M*log(N)) because inserting values into sorted sets is O(log(N)).",
+    "complexity": "O(1) to create the new key and additional O(N*M) to reconstruct the serialized value, where N is the number of Redis objects composing the value and M their average size. For small string values the time complexity is thus O(1)+O(1*M) where M is small, so O(1). However for sorted set values the complexity is O(N*M*log(N)) because inserting values into sorted sets is O(log(N)).",
     "arguments": [
       {
         "name": "key",

--- a/commands/bitcount.md
+++ b/commands/bitcount.md
@@ -43,7 +43,7 @@ the current day the user visited the web site using the `SETBIT` command setting
 the bit corresponding to the current day.
 
 Later it will be trivial to know the number of single days the user visited the
-web site simply calling the `BITCOUNT` command against the bitmap.
+web site calling the `BITCOUNT` command against the bitmap.
 
 A similar pattern where user IDs are used instead of days is described
 in the article called "[Fast easy realtime metrics using Redis

--- a/commands/blpop.md
+++ b/commands/blpop.md
@@ -130,7 +130,7 @@ LOOP forever
 END
 ```
 
-While in the producer side we'll use simply:
+While in the producer side we'll use:
 
 ```
 MULTI

--- a/commands/cluster-forget.md
+++ b/commands/cluster-forget.md
@@ -9,7 +9,7 @@ completely removed from a cluster, the `CLUSTER FORGET` command must be
 sent to all the remaining nodes, regardless of the fact they are masters
 or slaves.
 
-However the command cannot simply drop the node from the internal node
+However the command cannot drop the node from the internal node
 table of the node receiving the command, it also implements a ban-list, not
 allowing the same node to be added again as a side effect of processing the
 *gossip section* of the heartbeat packets received from other nodes.

--- a/commands/eval.md
+++ b/commands/eval.md
@@ -149,8 +149,8 @@ As you can see 3.333 is converted into 3, and the *bar* string is never returned
 
 There are two helper functions to return Redis types from Lua.
 
-* `redis.error_reply(error_string)` returns an error reply. This function simply returns a single field table with the `err` field set to the specified string for you.
-* `redis.status_reply(status_string)` returns a status reply. This function simply returns a single field table with the `ok` field set to the specified string for you.
+* `redis.error_reply(error_string)` returns an error reply. This function returns a single field table with the `err` field set to the specified string for you.
+* `redis.status_reply(status_string)` returns a status reply. This function returns a single field table with the `ok` field set to the specified string for you.
 
 There is no difference between using the helper functions or directly returning the table with the specified format, so the following two forms are equivalent:
 
@@ -269,7 +269,7 @@ between two different commands.
 * The connection we have with the server is persistent and was never closed so far.
 * The client explicitly checks the `runid` field in the `INFO` command in order to make sure the server was not restarted and is still the same process.
 
-Practically speaking, for the client it is much better to simply assume that in the context of a given connection, cached scripts are guaranteed to be there
+Practically speaking, for the client it is much better to assume that in the context of a given connection, cached scripts are guaranteed to be there
 unless an administrator explicitly called the `SCRIPT FLUSH` command.
 
 The fact that the user can count on Redis not removing scripts is semantically
@@ -429,7 +429,7 @@ following elements:
 ```
 
 In order to make it a pure function, but still be sure that every invocation
-of the script will result in different random elements, we can simply add an
+of the script will result in different random elements, we can add an
 additional argument to the script that will be used in order to seed the Lua
 pseudo-random number generator.
 The new script is as follows:
@@ -725,7 +725,7 @@ They correspond directly to the normal Redis log levels.
 Only logs emitted by scripting using a log level that is equal or greater than
 the currently configured Redis instance log level will be emitted.
 
-The `message` argument is simply a string.
+The `message` argument is a string.
 Example:
 
 ```

--- a/commands/expire.md
+++ b/commands/expire.md
@@ -97,7 +97,7 @@ using `RPUSH`.
 ## Keys with an expire
 
 Normally Redis keys are created without an associated time to live.
-The key will simply live forever, unless it is removed by the user in an
+The key will live forever, unless it is removed by the user in an
 explicit way, for instance using the `DEL` command.
 
 The `EXPIRE` family of commands is able to associate an expire to a given key,
@@ -135,7 +135,7 @@ lasting for 1000 seconds.
 
 Redis keys are expired in two ways: a passive way, and an active way.
 
-A key is passively expired simply when some client tries to access it, and the
+A key is passively expired when some client tries to access it, and the
 key is found to be timed out.
 
 Of course this is not enough as there are expired keys that will never be

--- a/commands/incr.md
+++ b/commands/incr.md
@@ -29,12 +29,12 @@ GET mykey
 
 The counter pattern is the most obvious thing you can do with Redis atomic
 increment operations.
-The idea is simply send an `INCR` command to Redis every time an operation
+The idea is send an `INCR` command to Redis every time an operation
 occurs.
 For instance in a web application we may want to know how many page views this
 user did every day of the year.
 
-To do so the web application may simply increment a key every time the user
+To do so the web application may increment a key every time the user
 performs a page view, creating the key name concatenating the User ID and a
 string representing the current date.
 

--- a/commands/setnx.md
+++ b/commands/setnx.md
@@ -87,7 +87,7 @@ Let's see how C4, our sane client, uses the good algorithm:
 *   If another client, for instance C5, was faster than C4 and acquired the lock
     with the `GETSET` operation, the C4 `GETSET` operation will return a non
     expired timestamp.
-    C4 will simply restart from the first step.
+    C4 will restart from the first step.
     Note that even if C4 set the key a bit a few seconds in the future this is
     not a problem.
 

--- a/commands/shutdown.md
+++ b/commands/shutdown.md
@@ -7,7 +7,7 @@ The command behavior is the following:
 
 If persistence is enabled this commands makes sure that Redis is switched off
 without the lost of any data.
-This is not guaranteed if the client uses simply `SAVE` and then `QUIT` because
+This is not guaranteed if the client uses `SAVE` and then `QUIT` because
 other clients may alter the DB data between the two commands.
 
 Note: A Redis instance that is configured for not persisting on disk (no AOF
@@ -35,7 +35,7 @@ system is in a state that does not allow to safely immediately persist
 on disk.
 
 Normally if there is an AOF child process performing an AOF rewrite, Redis
-will simply kill it and exit. However there are two conditions where it is
+will kill it and exit. However there are two conditions where it is
 unsafe to do so, and the **SHUTDOWN** command will be refused with an error
 instead. This happens when:
 

--- a/commands/zrangebyscore.md
+++ b/commands/zrangebyscore.md
@@ -58,7 +58,7 @@ ZRANGEBYSCORE myzset (1 (2
 
 ## Pattern: weighted random selection of an element
 
-Normally `ZRANGEBYSCORE` is simply used in order to get range of items
+Normally `ZRANGEBYSCORE` is used in order to get range of items
 where the score is the indexed integer key, however it is possible to do less
 obvious things with the command.
 

--- a/topics/clients.md
+++ b/topics/clients.md
@@ -122,7 +122,7 @@ if the client is idle for many seconds: the connection will remain open forever.
 However if you don't like this behavior, you can configure a timeout, so that
 if the client is idle for more than the specified number of seconds, the client connection will be closed.
 
-You can configure this limit via `redis.conf` or simply using `CONFIG SET timeout <value>`.
+You can configure this limit via `redis.conf` or using `CONFIG SET timeout <value>`.
 
 Note that the timeout only applies to normal clients and it **does not apply to Pub/Sub clients**, since a Pub/Sub connection is a *push style* connection so a client that is idle is the norm.
 

--- a/topics/cluster-spec.md
+++ b/topics/cluster-spec.md
@@ -356,7 +356,7 @@ slave nodes. The node will analyze the query, and if it is acceptable
 mentioned are all to the same hash slot) it will lookup what
 node is responsible for the hash slot where the key or keys belong.
 
-If the hash slot is served by the node, the query is simply processed, otherwise
+If the hash slot is served by the node, the query is processed, otherwise
 the node will check its internal hash slot to node map, and will reply
 to the client with a MOVED error, like in the following example:
 
@@ -424,7 +424,7 @@ The following subcommands are available (among others not useful in this case):
 * `CLUSTER SETSLOT` slot MIGRATING node
 * `CLUSTER SETSLOT` slot IMPORTING node
 
-The first two commands, `ADDSLOTS` and `DELSLOTS`, are simply used to assign
+The first two commands, `ADDSLOTS` and `DELSLOTS`, are used to assign
 (or remove) slots to a Redis node. Assigning a slot means to tell a given
 master node that it will be in charge of storing and serving content for
 the specified hash slot.
@@ -507,7 +507,7 @@ ASK redirection
 ---
 
 In the previous section we briefly talked about ASK redirection. Why can't
-we simply use MOVED redirection? Because while MOVED means that
+we use MOVED redirection? Because while MOVED means that
 we think the hash slot is permanently served by a different node and the
 next queries should be tried against the specified node, ASK means to
 send only the next query to the specified node.
@@ -551,7 +551,7 @@ be redirected, such a client would be very inefficient.
 
 Redis Cluster clients should try to be smart enough to memorize the slots
 configuration. However this configuration is not *required* to be up to date.
-Since contacting the wrong node will simply result in a redirection, that
+Since contacting the wrong node will result in a redirection, that
 should trigger an update of the client view.
 
 Clients usually need to fetch a complete list of slots and mapped node
@@ -878,7 +878,7 @@ Master `currentEpoch` is 5, lastVoteEpoch is 1 (this may happen after a few fail
 
 4. Masters don't vote for a slave of the same master before `NODE_TIMEOUT * 2` has elapsed if a slave of that master was already voted for. This is not strictly required as it is not possible for two slaves to win the election in the same epoch. However, in practical terms it ensures that when a slave is elected it has plenty of time to inform the other slaves and avoid the possibility that another slave will win a new election, performing an unnecessary second failover.
 5. Masters make no effort to select the best slave in any way. If the slave's master is in `FAIL` state and the master did not vote in the current term, a positive vote is granted. The best slave is the most likely to start an election and win it before the other slaves, since it will usually be able to start the voting process earlier because of its *higher rank* as explained in the previous section.
-6. When a master refuses to vote for a given slave there is no negative response, the request is simply ignored.
+6. When a master refuses to vote for a given slave there is no negative response, the request is ignored.
 7. Masters don't vote for slaves sending a `configEpoch` that is less than any `configEpoch` in the master table for the slots claimed by the slave. Remember that the slave sends the `configEpoch` of its master, and the bitmap of the slots served by its master. This means that the slave requesting the vote must have a configuration for the slots it wants to failover that is newer or equal the one of the master granting the vote.
 
 Practical example of configuration epoch usefulness during partitions
@@ -918,7 +918,7 @@ There are two ways hash slot configurations are propagated:
 2. `UPDATE` messages. Since in every heartbeat packet there is information about the sender `configEpoch` and set of hash slots served, if a receiver of a heartbeat packet finds the sender information is stale, it will send a packet with new information, forcing the stale node to update its info.
 
 The receiver of a heartbeat or `UPDATE` message uses certain simple rules in
-order to update its table mapping hash slots to nodes. When a new Redis Cluster node is created, its local hash slot table is simply initialized to `NULL` entries so that each hash slot is not bound or linked to any node. This looks similar to the following:
+order to update its table mapping hash slots to nodes. When a new Redis Cluster node is created, its local hash slot table is initialized to `NULL` entries so that each hash slot is not bound or linked to any node. This looks similar to the following:
 
 ```
 0 -> NULL
@@ -1213,7 +1213,7 @@ In a Redis Cluster clients can subscribe to every node, and can also
 publish to every other node. The cluster will make sure that published
 messages are forwarded as needed.
 
-The current implementation will simply broadcast each published message
+The current implementation will broadcast each published message
 to all other nodes, but at some point this will be optimized either
 using Bloom filters or other algorithms.
 

--- a/topics/cluster-tutorial.md
+++ b/topics/cluster-tutorial.md
@@ -86,7 +86,7 @@ Redis Cluster does not use consistent hashing, but a different form of sharding
 where every key is conceptually part of what we call an **hash slot**.
 
 There are 16384 hash slots in Redis Cluster, and to compute what is the hash
-slot of a given key, we simply take the CRC16 of the key modulo
+slot of a given key, we take the CRC16 of the key modulo
 16384.
 
 Every node in a Redis Cluster is responsible for a subset of the hash slots,
@@ -248,10 +248,10 @@ cluster-node-timeout 5000
 appendonly yes
 ```
 
-As you can see what enables the cluster mode is simply the `cluster-enabled`
+As you can see what enables the cluster mode is the `cluster-enabled`
 directive. Every instance also contains the path of a file where the
 configuration for this node is stored, which by default is `nodes.conf`.
-This file is never touched by humans; it is simply generated at startup
+This file is never touched by humans; it is generated at startup
 by the Redis Cluster instances, and updated every time it is needed.
 
 Note that the **minimal cluster** that works as expected requires to contain
@@ -292,7 +292,7 @@ This ID will be used forever by this specific instance in order for the instance
 to have a unique name in the context of the cluster. Every node
 remembers every other node using this IDs, and not by IP or port.
 IP addresses and ports may change, but the unique node identifier will never
-change for all the life of the node. We call this identifier simply **Node ID**.
+change for all the life of the node. We call this identifier **Node ID**.
 
 Creating the cluster
 ---
@@ -312,7 +312,7 @@ You need to install `redis` gem to be able to run `redis-trib`.
 
     gem install redis
 
- To create your cluster simply type:
+ To create your cluster type:
 
     ./redis-trib.rb create --replicas 1 127.0.0.1:7000 127.0.0.1:7001 \
     127.0.0.1:7002 127.0.0.1:7003 127.0.0.1:7004 127.0.0.1:7005
@@ -380,7 +380,7 @@ I'm aware of the following implementations:
 * The `redis-cli` utility in the unstable branch of the Redis repository at GitHub implements a very basic cluster support when started with the `-c` switch.
 
 An easy way to test Redis Cluster is either to try any of the above clients
-or simply the `redis-cli` command line utility. The following is an example
+or the `redis-cli` command line utility. The following is an example
 of interaction using the latter:
 
 ```
@@ -942,7 +942,7 @@ to another under certain condition, is that usually the Redis Cluster is as
 resistant to failures as the number of replicas attached to a given master.
 
 For example a cluster where every master has a single replica can't continue
-operations if the master and its replica fail at the same time, simply because
+operations if the master and its replica fail at the same time, because
 there is no other instance to have a copy of the hash slots the master was
 serving. However while netsplits are likely to isolate a number of nodes
 at the same time, many other kind of failures, like hardware or software failures

--- a/topics/data-types-intro.md
+++ b/topics/data-types-intro.md
@@ -17,7 +17,7 @@ by Redis, which will be covered separately in this tutorial:
 * Hashes, which are maps composed of fields associated with values. Both the
   field and the value are strings. This is very similar to Ruby or Python
   hashes.
-* Bit arrays (or simply bitmaps): it is possible, using special commands, to
+* Bit arrays (or bitmaps): it is possible, using special commands, to
   handle String values like an array of bits: you can set and clear individual
   bits, count all the bits set to 1, find the first set or unset bit, and so
   forth.
@@ -962,13 +962,13 @@ Common use cases for bitmaps are:
 For example imagine you want to know the longest streak of daily visits of
 your web site users. You start counting days starting from zero, that is the
 day you made your web site public, and set a bit with `SETBIT` every time
-the user visits the web site. As a bit index you simply take the current unix
+the user visits the web site. As a bit index you take the current unix
 time, subtract the initial offset, and divide by 3600\*24.
 
 This way for each user you have a small string containing the visit
 information for each day. With `BITCOUNT` it is possible to easily get
 the number of days a given user visited the web site, while with
-a few `BITPOS` calls, or simply fetching and analyzing the bitmap client-side,
+a few `BITPOS` calls, or fetching and analyzing the bitmap client-side,
 it is possible to easily compute the longest streak.
 
 Bitmaps are trivial to split into multiple keys, for example for

--- a/topics/data-types.md
+++ b/topics/data-types.md
@@ -23,7 +23,7 @@ Check all the [available string commands](/commands/#string) for more informatio
 Lists
 ---
 
-Redis Lists are simply lists of strings, sorted by insertion order.
+Redis Lists are lists of strings, sorted by insertion order.
 It is possible to add elements to a Redis List pushing new elements on the head  (on the left) or on the tail (on the right) of the list.
 
 The [LPUSH](/commands/lpush) command inserts a new element on the head, while
@@ -76,7 +76,7 @@ The max number of members in a set is 2^32 - 1 (4294967295, more than 4 billion 
 
 You can do many interesting things using Redis Sets, for instance you can:
 
-* You can track unique things using Redis Sets. Want to know all the unique IP addresses visiting a given blog post? Simply use [SADD](/commands/sadd) every time you process a page view. You are sure repeated IPs will not be inserted.
+* You can track unique things using Redis Sets. Want to know all the unique IP addresses visiting a given blog post? Use [SADD](/commands/sadd) every time you process a page view. You are sure repeated IPs will not be inserted.
 * Redis Sets are good to represent relations. You can create a tagging system with Redis using a Set to represent every tag. Then you can add all the IDs of all the objects having a given tag into a Set representing this particular tag, using the [SADD](/commands/sadd) command. Do you want all the IDs of all the Objects having three different tags at the same time? Just use [SINTER](/commands/sinter).
 * You can use Sets to extract elements at random using the [SPOP](/commands/spop) or [SRANDMEMBER](/commands/srandmember) commands.
 

--- a/topics/indexes.md
+++ b/topics/indexes.md
@@ -106,7 +106,7 @@ time to time, and the index to reflect this change.
 
 The `ZADD` command makes updating simple indexes a very trivial operation
 since re-adding back an element with a different score and the same value
-will simply update the score and move the element at the right position,
+will update the score and move the element at the right position,
 so if the user `antirez` turned 39 years old, in order to update the
 data in the hash representing the user, and in the index as well, we need
 to execute the following two commands:
@@ -295,7 +295,7 @@ performed a single time, so we end presenting it to the user.
 
 This is what we can do. Out of the returned items, we pick a random one,
 decrement its score by one, and re-add it with the new score.
-However if the score reaches 0, we simply remove the item from the list.
+However if the score reaches 0, we remove the item from the list.
 You can use much more advanced systems, but the idea is that the index in
 the long run will contain top searches, and if top searches will change over
 the time it will adapt automatically.

--- a/topics/internals-vm.md
+++ b/topics/internals-vm.md
@@ -133,7 +133,7 @@ vmSwapOneObject acts performing the following steps:
  * The key storage field is set to REDIS_VM_SWAPPED, while the _vm_ fields of the object are set to the right values (the page index where the object was swapped, and the number of pages used to swap it).
  * Finally the value object is freed and the value entry of the hash table is set to NULL.
 
-The function is called again and again until one of the following happens: there is no way to swap more objects because either the swap file is full or nearly all the objects are already transferred on disk, or simply the memory usage is already under the vm-max-memory parameter.
+The function is called again and again until one of the following happens: there is no way to swap more objects because either the swap file is full or nearly all the objects are already transferred on disk, or the memory usage is already under the vm-max-memory parameter.
 
 What values to swap when we are out of memory?
 ---

--- a/topics/latency.md
+++ b/topics/latency.md
@@ -282,7 +282,7 @@ The kernel relocates Redis memory pages on disk mainly because of three reasons:
 
 * The system is under memory pressure since the running processes are demanding
 more physical memory than the amount that is available. The simplest instance of
-this problem is simply Redis using more memory than the one available.
+this problem is Redis using more memory than the one available.
 * The Redis instance data set, or part of the data set, is mostly completely idle
 (never accessed by clients), so the kernel could swap idle memory pages on disk.
 This problem is very rare since even a moderately slow instance will touch all
@@ -489,7 +489,7 @@ modified at runtime using the **CONFIG SET** command).
 
 * When appendfsync is set to the value of **no** Redis performs no fsync.
 In this configuration the only source of latency can be write(2).
-When this happens usually there is no solution since simply the disk can't
+When this happens usually there is no solution since the disk can't
 cope with the speed at which Redis is receiving data, however this is
 uncommon if the disk is not seriously slowed down by other processes doing
 I/O.

--- a/topics/partitioning.md
+++ b/topics/partitioning.md
@@ -70,7 +70,7 @@ Since Redis is extremely small footprint and lightweight (a spare instance uses 
 
 And you can select this number of instances to be quite big since the start. For example, 32 or 64 instances could do the trick for most users, and will provide enough room for growth.
 
-In this way as your data storage needs increase and you need more Redis servers, what to do is to simply move instances from one server to another. Once you add the first additional server, you will need to move half of the Redis instances from the first server to the second, and so forth.
+In this way as your data storage needs increase and you need more Redis servers, what to do is to move instances from one server to another. Once you add the first additional server, you will need to move half of the Redis instances from the first server to the second, and so forth.
 
 Using Redis replication you will likely be able to do the move with minimal or no downtime for your users:
 

--- a/topics/persistence.md
+++ b/topics/persistence.md
@@ -51,7 +51,7 @@ The general indication is that you should use both persistence methods if
 you want a degree of data safety comparable to what PostgreSQL can provide you.
 
 If you care a lot about your data, but still can live with a few minutes of
-data loss in case of disasters, you can simply use RDB alone.
+data loss in case of disasters, you can use RDB alone.
 
 There are many users using AOF alone, but we discourage it since to have an
 RDB snapshot from time to time is a great idea for doing database backups,
@@ -269,7 +269,7 @@ Since many Redis users are in the startup scene and thus don't have plenty
 of money to spend we'll review the most interesting disaster recovery techniques
 that don't have too high costs.
 
-* Amazon S3 and other similar services are a good way for mounting your disaster recovery system. Simply transfer your daily or hourly RDB snapshot to S3 in an encrypted form. You can encrypt your data using `gpg -c` (in symmetric encryption mode). Make sure to store your password in many different safe places (for instance give a copy to the most important people of your organization). It is recommended to use multiple storage services for improved data safety.
+* Amazon S3 and other similar services are a good way for mounting your disaster recovery system. Transfer your daily or hourly RDB snapshot to S3 in an encrypted form. You can encrypt your data using `gpg -c` (in symmetric encryption mode). Make sure to store your password in many different safe places (for instance give a copy to the most important people of your organization). It is recommended to use multiple storage services for improved data safety.
 * Transfer your snapshots using SCP (part of SSH) to far servers. This is a fairly simple and safe route: get a small VPS in a place that is very far from you, install ssh there, and generate an ssh client key without passphrase, then add it in the authorized_keys file of your small VPS. You are ready to transfer
 backups in an automated fashion. Get at least two VPS in two different providers
 for best results.

--- a/topics/protocol.md
+++ b/topics/protocol.md
@@ -118,7 +118,7 @@ A client implementation may return different kind of exceptions for different
 errors, or may provide a generic way to trap errors by directly providing
 the error name to the caller as a string.
 
-However, such a feature should not be considered vital as it is rarely useful, and a limited client implementation may simply return a generic error condition, such as `false`.
+However, such a feature should not be considered vital as it is rarely useful, and a limited client implementation may return a generic error condition, such as `false`.
 
 <a name="integer-reply"></a>
 
@@ -339,7 +339,7 @@ The following is another example of an inline command returning an integer:
     C: EXISTS somekey
     S: :0
 
-Basically you simply write space-separated arguments in a telnet session.
+Basically you write space-separated arguments in a telnet session.
 Since no command starts with `*` that is instead used in the unified request
 protocol, Redis is able to detect this condition and parse your command.
 

--- a/topics/rdd-1.md
+++ b/topics/rdd-1.md
@@ -14,7 +14,7 @@ in order to modify or evolve Redis. Every new Redis Design Draft is published
 in the Redis mailing list and announced on Twitter, in the hope to receive
 feedback before implementing a given feature.
 
-The way the community can provide feedback about a RDD is simply writing
+The way the community can provide feedback about a RDD is writing
 a message to the Redis mailing list, or commenting in the associated
 GitHub issue if any.
 

--- a/topics/rdd-2.md
+++ b/topics/rdd-2.md
@@ -69,7 +69,7 @@ the remaining of the RDB file contains the key-value pairs.
 
 ## Handling of info fields
 
-A program can simply skip every info field it does not understand, as long
+A program can skip every info field it does not understand, as long
 as the RDB version matches the one that it is capable to load.
 
 ## Specification of info fields IDs and content.

--- a/topics/rediscli.md
+++ b/topics/rediscli.md
@@ -524,7 +524,7 @@ similar to any other command. Subscribing to channels in order to receive
 messages is different - in this case we need to block and wait for
 messages, so this is implemented as a special mode in `redis-cli`. Unlike
 other special modes this mode is not enabled by using a special option,
-but simply by using the `SUBSCRIBE` or `PSUBSCRIBE` command, both in
+but by using the `SUBSCRIBE` or `PSUBSCRIBE` command, both in
 interactive or non interactive mode:
 
     $ redis-cli psubscribe '*'
@@ -676,7 +676,7 @@ The slave mode of the CLI is an advanced feature useful for
 Redis developers and for debugging operations.
 It allows to inspect what a master sends to its slaves in the replication
 stream in order to propagate the writes to its replicas. The option
-name is simply `--slave`. This is how it works:
+name is `--slave`. This is how it works:
 
     $ redis-cli --slave
     SYNC with master, discarding 13256 bytes of bulk transfer...

--- a/topics/replication.md
+++ b/topics/replication.md
@@ -48,7 +48,7 @@ connections during this brief window (that can be as long as many seconds for ve
 
 * Replication can be used both for scalability, in order to have
 multiple slaves for read-only queries (for example, slow O(N)
-operations can be offloaded to slaves), or simply for data safety.
+operations can be offloaded to slaves), or for data safety.
 
 * It is possible to use replication to avoid the cost of having the master write the full dataset to disk: a typical technique involves configuring your master `redis.conf` to avoid persisting to disk at all, then connect a slave configured to save from time to time, or with AOF enabled. However this setup must be handled with care, since a restarting master will start with an empty dataset: if the slave tries to synchronized with it, the slave will be emptied as well.
 

--- a/topics/security.md
+++ b/topics/security.md
@@ -57,7 +57,7 @@ Protected mode
 ---
 
 Unfortunately many users fail to protect Redis instances from being accessed
-from external networks. Many instances are simply left exposed on the
+from external networks. Many instances are left exposed on the
 internet with public IPs. For this reasons since version 3.2.0, when Redis is
 executed with the default configuration (binding all the interfaces) and
 without any password in order to access it, it enters a special mode called

--- a/topics/sentinel-clients.md
+++ b/topics/sentinel-clients.md
@@ -86,7 +86,7 @@ Sentinel failover disconnection
 
 Starting with Redis 2.8.12, when Redis Sentinel changes the configuration of
 an instance, for example promoting a slave to a master, demoting a master to
-replicate to the new master after a failover, or simply changing the master
+replicate to the new master after a failover, or changing the master
 address of a stale slave instance, it sends a `CLIENT KILL type normal`
 command to the instance in order to make sure all the clients are disconnected
 from the reconfigured instance. This will force clients to resolve the master

--- a/topics/sentinel-old.md
+++ b/topics/sentinel-old.md
@@ -201,7 +201,7 @@ Sentinel commands
 
 The following is a list of accepted commands:
 
-* **PING** this command simply returns PONG.
+* **PING** this command returns PONG.
 * **SENTINEL masters** show a list of monitored masters and their state.
 * **SENTINEL slaves `<master name>`** show a list of slaves for this master, and their state.
 * **SENTINEL is-master-down-by-addr `<ip> <port>`** return a two elements multi bulk reply where the first is 0 or 1 (0 if the master with that address is known and is in `SDOWN` state, 1 otherwise). The second element of the reply is the
@@ -222,7 +222,7 @@ The channel name is the same as the name of the event. For instance the
 channel named `+sdown` will receive all the notifications related to instances
 entering an `SDOWN` condition.
 
-To get all the messages simply subscribe using `PSUBSCRIBE *`.
+To get all the messages subscribe using `PSUBSCRIBE *`.
 
 The following is a list of channels and message formats you can receive using
 this API. The first word is the channel / event name, the rest is the format of the data.

--- a/topics/sentinel-spec.md
+++ b/topics/sentinel-spec.md
@@ -15,7 +15,7 @@ Introduction
 
 Redis Sentinel is the name of the Redis high availability solution that's
 currently under development. It has nothing to do with Redis Cluster and
-is intended to be used by people that don't need Redis Cluster, but simply
+is intended to be used by people that don't need Redis Cluster, but
 a way to perform automatic fail over when a master instance is not functioning
 correctly.
 
@@ -301,7 +301,7 @@ still sees a master in `O_DOWN` condition.
 
 The observer is still able to follow and update the internal state based on
 what is happening with the failover, but does not directly rely on the
-Leader to communicate with it to be informed by progresses. It simply observes
+Leader to communicate with it to be informed by progresses. It observes
 the state of the slaves to understand what is happening.
 
 Specifically the observers flags the master as `FAILOVER_IN_PROGRESS` if a slave

--- a/topics/sentinel.md
+++ b/topics/sentinel.md
@@ -66,7 +66,7 @@ Sentinel mode:
 
 Both ways work the same.
 
-However **it is mandatory** to use a configuration file when running Sentinel, as this file will be used by the system in order to save the current state that will be reloaded in case of restarts. Sentinel will simply refuse to start if no configuration file is given or if the configuration file path is not writable.
+However **it is mandatory** to use a configuration file when running Sentinel, as this file will be used by the system in order to save the current state that will be reloaded in case of restarts. Sentinel will refuse to start if no configuration file is given or if the configuration file path is not writable.
 
 Sentinels by default run **listening for connections to TCP port 26379**, so
 for Sentinels to work, port 26379 of your servers **must be open** to receive
@@ -587,7 +587,7 @@ Sentinel commands
 The following is a list of accepted commands, not covering commands used in
 order to modify the Sentinel configuration, which are covered later.
 
-* **PING** This command simply returns PONG.
+* **PING** This command returns PONG.
 * **SENTINEL masters** Show a list of monitored masters and their state.
 * **SENTINEL master `<master name>`** Show the state and info of the specified master.
 * **SENTINEL slaves `<master name>`** Show a list of slaves for this master, and their state.
@@ -613,7 +613,7 @@ The following is an example of `SENTINEL SET` command in order to modify the `do
 
     SENTINEL SET objects-cache-master down-after-milliseconds 1000
 
-As already stated, `SENTINEL SET` can be used to set all the configuration parameters that are settable in the startup configuration file. Moreover it is possible to change just the master quorum configuration without removing and re-adding the master with `SENTINEL REMOVE` followed by `SENTINEL MONITOR`, but simply using:
+As already stated, `SENTINEL SET` can be used to set all the configuration parameters that are settable in the startup configuration file. Moreover it is possible to change just the master quorum configuration without removing and re-adding the master with `SENTINEL REMOVE` followed by `SENTINEL MONITOR`, but using:
 
     SENTINEL SET objects-cache-master quorum 5
 
@@ -682,7 +682,7 @@ channel named `+sdown` will receive all the notifications related to instances
 entering an `SDOWN` (SDOWN means the instance is no longer reachable from
 the point of view of the Sentinel you are querying) condition.
 
-To get all the messages simply subscribe using `PSUBSCRIBE *`.
+To get all the messages subscribe using `PSUBSCRIBE *`.
 
 The following is a list of channels and message formats you can receive using
 this API. The first word is the channel / event name, the rest is the format of the data.

--- a/topics/transactions.md
+++ b/topics/transactions.md
@@ -203,7 +203,7 @@ all. (Note that if you `WATCH` a volatile key and Redis expires
 the key after you `WATCH`ed it, `EXEC` will still work. [More on
 this](http://code.google.com/p/redis/issues/detail?id=270).)
 
-`WATCH` can be called multiple times. Simply all the `WATCH` calls will
+`WATCH` can be called multiple times. All the `WATCH` calls will
 have the effects to watch for changes starting from the call, up to
 the moment `EXEC` is called. You can also send any number of keys to a
 single `WATCH` call.

--- a/topics/twitter-clone.md
+++ b/topics/twitter-clone.md
@@ -411,7 +411,7 @@ Now it should be pretty clear how we can use `LRANGE` in order to get ranges of 
         return count($posts) == $count+1;
     }
 
-`showPost` will simply convert and print a Post in HTML while `showUserPosts` gets a range of posts and then passes them to `showPosts`.
+`showPost` will convert and print a Post in HTML while `showUserPosts` gets a range of posts and then passes them to `showPosts`.
 
 *Note: `LRANGE` is not very efficient if the list of posts start to be very
 big, and we want to access elements which are in the middle of the list, since Redis Lists are backed by linked lists. If a system is designed for

--- a/topics/virtual-memory.md
+++ b/topics/virtual-memory.md
@@ -1,4 +1,4 @@
-**IMPORTANT NOTE:** Redis VM is now deprecated. Redis 2.4 will be the latest Redis version featuring Virtual Memory (but it also warns you that Virtual Memory usage is discouraged). We found that using VM has several disadvantages and problems. In the future of Redis we want to simply provide the best in-memory database (but persistent on disk as usual) ever, without considering at least for now the support for databases bigger than RAM. Our future efforts are focused into providing scripting, cluster, and better persistence.
+**IMPORTANT NOTE:** Redis VM is now deprecated. Redis 2.4 will be the latest Redis version featuring Virtual Memory (but it also warns you that Virtual Memory usage is discouraged). We found that using VM has several disadvantages and problems. In the future of Redis we want to provide the best in-memory database (but persistent on disk as usual) ever, without considering at least for now the support for databases bigger than RAM. Our future efforts are focused into providing scripting, cluster, and better persistence.
 
 Virtual Memory
 ===
@@ -36,7 +36,7 @@ is not possible:
 * Data access is very biased. Only a small percentage of keys (for instance
   related to active users in your web site) gets the vast majority of accesses.
   At the same time there is too much data per key to take everything in memory.
-* There is simply not enough memory available to hold all the data in memory,
+* There is not enough memory available to hold all the data in memory,
   regardless of the data access pattern, and values are large. In this
   configuration Redis can be used as an on-disk DB where keys are in memory, so
   the key lookup is fast, but the access to the actual values require accessing


### PR DESCRIPTION
I believe that the word "simply" in documentation is harmful. At best, "simply" is unnecessary filler, and at worst, it's an inflammatory word which shames readers. I'm on a bit of a mission to remove "simply" from software documentation, and as part of that, I created [a script called `dont-say-simply`](https://github.com/jameshfisher/dont-say-simply) which removes all uses of the word "simply" from a GitHub repository. That script created this PR. You can read more about my reasoning [here](https://github.com/jameshfisher/dont-say-simply).