### PR TITLE
updated EX and PX documentation

### DIFF
--- a/commands.json
+++ b/commands.json
@@ -2225,15 +2225,9 @@
         "type": "string"
       },
       {
-        "command": "EX",
-        "name": "seconds",
-        "type": "integer",
-        "optional": true
-      },
-      {
-        "command": "PX",
-        "name": "milliseconds",
-        "type": "integer",
+        "command": "expiration",
+        "type": "enum",
+        "enum": ["EX seconds", "PX milliseconds"],
         "optional": true
       },
       {


### PR DESCRIPTION
The Set command documentation says:  SET key value [EX seconds] [PX milliseconds] [NX\|XX]. https://redis.io/commands/set According to this I should be able to execute SET foo bar ex 1 px 200  (which could be used to model an expiration time of 1 sec and 200 ms).  Obviously this isn't possible, which is fine because I can use a PX of  1200 to model this use case. However: Shouldn't the documentation say SET key value [EX seconds \| PX milliseconds] [NX\|XX]?

