### PR TITLE
SET signature containing misleading "expiration"

### DIFF
--- a/commands.json
+++ b/commands.json
@@ -2225,7 +2225,7 @@
         "type": "string"
       },
       {
-        "command": "expiration",
+        "name": "expiration",
         "type": "enum",
         "enum": ["EX seconds", "PX milliseconds"],
         "optional": true


### PR DESCRIPTION
@antirez & @itamarhaber sorry, I accidentally used "command" instead of "name". Fixed it. 