### PR TITLE
Add XINFO, XGROUP, XACK, XTRIM, XCLAIM, and XDEL to commands.json

### DIFF
--- a/commands.json
+++ b/commands.json
@@ -3567,9 +3567,7 @@
     "group": "stream"
   },
   "XACK": {
-    "summary": "Marks a pending message as correctly processed.
-
-Return value of the command is the number of messages successfully acknowledged, that is, the IDs we were actually able to resolve in the PEL.",
+    "summary": "Marks a pending message as correctly processed. Return value of the command is the number of messages successfully acknowledged, that is, the IDs we were actually able to resolve in the PEL.",
     "complexity": "",
     "arguments": [
       {

--- a/commands.json
+++ b/commands.json
@@ -3330,6 +3330,38 @@
     "since": "2.8.0",
     "group": "sorted_set"
   },
+  "XINFO": {
+    "summary": "Get information on streams and consumer groups",
+    "complexity": "",
+    "arguments": [
+      {
+        "command": "CONSUMERS",
+        "name": ["key", "groupname"],
+        "type": ["key", "string"],
+        "optional": true
+      },
+      {
+        "command": "GROUPS",
+        "name": "key",
+        "type": "key",
+        "optional": true
+      },
+      {
+        "command": "STREAM",
+        "name": "key",
+        "type": "key",
+        "optional": true
+      },
+      {
+        "name": "help",
+        "type": "enum",
+        "enum": ["HELP"],
+        "optional": true
+      }
+    ],
+    "since": "5.0.0",
+    "group": "stream"
+  },
   "XADD": {
     "summary": "Appends a new entry to a stream",
     "complexity": "O(log(N)) with N being the number of items already into the stream.",

--- a/commands.json
+++ b/commands.json
@@ -3351,6 +3351,50 @@
     "since": "5.0.0",
     "group": "stream"
   },
+  "XTRIM": {
+    "summary": "Trims the stream to (approximately if '~' is passed) a certain size",
+    "complexity": "O(log(N)) with N being the number of in the stream prior to trim.",
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key"
+      },
+      {
+        "name": "strategy",
+        "type": "enum",
+        "enum": ["MAXLEN"]
+      },
+      {
+        "name": "approx",
+        "type": "enum",
+        "enum": ["~"],
+        "optional": true
+      },
+      {
+        "name": "count",
+        "type": "integer"
+      }
+    ],
+    "since": "5.0.0",
+    "group": "stream"
+  },
+  "XDEL": {
+    "summary": "Removes the specified entries from the stream. Returns the number of items actually deleted, that may be different from the number of IDs passed in case certain IDs do not exist.",
+    "complexity": "O(log(N)) with N being the number of items in the stream.",
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key"
+      },
+      {
+        "name": "ID",
+        "type": "string",
+        "multiple": "true"
+      }
+    ],
+    "since": "5.0.0",
+    "group": "stream"
+  },
   "XRANGE": {
     "summary": "Return a range of elements in a stream, with IDs matching the specified IDs interval",
     "complexity": "O(log(N)+M) with N being the number of elements in the stream and M the number of elements being returned. If M is constant (e.g. always asking for the first 10 elements with COUNT), you can consider it O(log(N)).",
@@ -3450,6 +3494,38 @@
     "since": "5.0.0",
     "group": "stream"
   },
+  "XGROUP": {
+    "summary": "Create, destroy, and manage consumer groups.",
+    "complexity": "",
+    "arguments": [
+      {
+        "command": "CREATE",
+        "name": ["key", "groupname", "id-or-$"],
+        "type": ["key", "string", "string"],
+        "optional": true
+      },
+      {
+        "command": "SETID",
+        "name": ["key", "id-or-$"],
+        "type": ["key", "string"],
+        "optional": true
+      },
+      {
+        "command": "DESTROY",
+        "name": ["key", "groupname"],
+        "type": ["key", "string"],
+        "optional": true
+      },
+      {
+        "command": "DELCONSUMER",
+        "name": ["key", "groupname", "consumername"],
+        "type": ["key", "string", "string"],
+        "optional": true
+      }
+    ],
+    "since": "5.0.0",
+    "group": "stream"
+  },
   "XREADGROUP": {
     "summary": "Return new entries from a stream using a consumer group, or access the history of the pending entries for a given consumer. Can block.",
     "complexity": "For each stream mentioned: O(log(N)+M) with N being the number of elements in the stream and M the number of elements being returned. If M is constant (e.g. always asking for the first 10 elements with COUNT), you can consider it O(log(N)). On the other side, XADD will pay the O(N) time in order to serve the N clients blocked on the stream getting new data.",
@@ -3485,6 +3561,86 @@
         "name": "ID",
         "type": "string",
         "multiple": true
+      }
+    ],
+    "since": "5.0.0",
+    "group": "stream"
+  },
+  "XACK": {
+    "summary": "Marks a pending message as correctly processed.
+
+Return value of the command is the number of messages successfully acknowledged, that is, the IDs we were actually able to resolve in the PEL.",
+    "complexity": "",
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key"
+      },
+      {
+        "name": "group",
+        "type": "string"
+      },
+      {
+        "name": "ID",
+        "type": "string",
+        "multiple": true
+      }
+    ],
+    "since": "5.0.0",
+    "group": "stream"
+  },
+  "XCLAIM": {
+    "summary": "",
+    "complexity": "",
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key"
+      },
+      {
+        "name": "group",
+        "type": "string"
+      },
+      {
+        "name": "consumer",
+        "type": "string"
+      },
+      {
+        "name": "min-idle-time",
+        "type": "string"
+      },
+      {
+        "name": "ID",
+        "type": "string",
+        "multiple": true
+      },
+      {
+        "command": "IDLE",
+        "name": "ms",
+        "type": "integer",
+        "optional": true
+      },
+      {
+        "command": "TIME",
+        "name": "ms-unix-time",
+        "type": "integer",
+        "optional": true
+      },
+      {
+        "command": "RETRYCOUNT",
+        "name": "count",
+        "type": "integer",
+        "optional": true
+      },
+      {
+        "name": "force",
+        "enum": ["FORCE"],
+        "optional": true
+      },
+      {
+        "name": "justid",
+        "enum": ["JUSTID"],
+        "optional": true
       }
     ],
     "since": "5.0.0",


### PR DESCRIPTION
Fixes #943 

- Needs analysis for time "complexity" entries
- Summaries need reviewed, and XCLAIM summary needs added