### PR TITLE
Fixes SET's syntax

### DIFF
--- a/commands.json
+++ b/commands.json
@@ -2237,7 +2237,7 @@
         "type": "string"
       },
       {
-        "command": "expiration",
+        "name": "expiration",
         "type": "enum",
         "enum": ["EX seconds", "PX milliseconds"],
         "optional": true


### PR DESCRIPTION
Changes outputted syntax from the current:

```
SET key value [expiration EX seconds|PX milliseconds] [NX|XX]
```

to:

```
SET key value [EX seconds|PX milliseconds] [NX|XX]
```

Signed-off-by: Itamar Haber <itamar@redislabs.com>