### PR TITLE
Fix typo: "si" -> "is" in topics/modules-blocking-ops

### DIFF
--- a/topics/modules-blocking-ops.md
+++ b/topics/modules-blocking-ops.md
@@ -16,7 +16,7 @@ Redis modules have the ability to implement blocking commands as well,
 this documentation shows how the API works and describes a few patterns
 that can be used in order to model blocking commands.
 
-NOTE: This API si currently *experimental*, so it can only be used if
+NOTE: This API is currently *experimental*, so it can only be used if
 the macro `REDISMODULE_EXPERIMENTAL_API` is defined. This is required because
 these calls are still not in their final stage of design, so may change
 in the future, certain parts may be reprecated and so forth.


### PR DESCRIPTION
Fixed typo : si -> is