### PR TITLE
Redis Modules: update simplest module example

### DIFF
--- a/topics/modules-intro.md
+++ b/topics/modules-intro.md
@@ -71,7 +71,7 @@ simple module that implements a command that outputs a random number.
             == REDISMODULE_ERR) return REDISMODULE_ERR;
 
         if (RedisModule_CreateCommand(ctx,"helloworld.rand",
-            HelloworldRand_RedisCommand) == REDISMODULE_ERR)
+            HelloworldRand_RedisCommand,"readonly",0,0,0) == REDISMODULE_ERR)
             return REDISMODULE_ERR;
 
         return REDISMODULE_OK;


### PR DESCRIPTION
Hi, I found the "The simplest module you can write" example is out of date. 

Of course, we can not compatible with all versions, i think the documentation should be consistent with the latest version.

Looking forward to your reply. D#-#

Signed-off-by: charpty <charpty@gmail.com>