### PR TITLE
Redis modules introduce: fix typo in "creating new keys" example

### DIFF
--- a/topics/modules-intro.md
+++ b/topics/modules-intro.md
@@ -573,7 +573,7 @@ To create a new key, open it for writing and then write to it using one
 of the key writing functions. Example:
 
     RedisModuleKey *key;
-    key = RedisModule_OpenKey(ctx,argv[1],REDISMODULE_READ);
+    key = RedisModule_OpenKey(ctx,argv[1],REDISMODULE_WRITE);
     if (RedisModule_KeyType(key) == REDISMODULE_KEYTYPE_EMPTY) {
         RedisModule_StringSet(key,argv[2]);
     }


### PR DESCRIPTION
In chapter "Arity and type checks", there is a mistake: 
```
To create a new key, open it for writing and then write to it using one of the key writing functions. Example:

RedisModuleKey *key;

// I think here should be REDISMODULE_WRITE for create new key
key = RedisModule_OpenKey(ctx,argv[1],REDISMODULE_READ);

if (RedisModule_KeyType(key) == REDISMODULE_KEYTYPE_EMPTY) {
    RedisModule_StringSet(key,argv[2]);
}
```

Looking forward to your reply. D#-#

Signed-off-by: charpty <charpty@gmail.com>