### PR TITLE
Fix groupname argument of XGROUP

### DIFF
--- a/commands.json
+++ b/commands.json
@@ -3589,8 +3589,8 @@
       },
       {
         "command": "SETID",
-        "name": ["key", "id-or-$"],
-        "type": ["key", "string"],
+        "name": ["key", "groupname", "id-or-$"],
+        "type": ["key", "string", "string"],
         "optional": true
       },
       {

--- a/commands/xgroup.md
+++ b/commands/xgroup.md
@@ -27,7 +27,7 @@ limits to the number of consumer groups you can associate to a given stream.
 
 A consumer can be destroyed completely by using the following form:
 
-    XGROUP DESTROY mystream some-consumer-group
+    XGROUP DESTROY mystream consumer-group-name
 
 The consumer group will be destroyed even if there are active consumers
 and pending messages, so make sure to call this command only when really
@@ -36,7 +36,7 @@ needed.
 To just remove a given consumer from a consumer group, the following
 form is used:
 
-    XGROUP DELCONSUMER mystream consumergrouo myconsumer123
+    XGROUP DELCONSUMER mystream consumer-group-name myconsumer123
 
 Consumers in a consumer group are auto-created every time a new consumer
 name is mentioned by some command. However sometimes it may be useful to
@@ -51,7 +51,7 @@ group again. For instance if you want the consumers in a consumer group
 to re-process all the messages in a stream, you may want to set its next
 ID to 0:
 
-    XGROUP SETID mystream my-consumer-group 0
+    XGROUP SETID mystream consumer-group-name 0
 
 Finally to get some help if you don't remember the syntax, use the
 HELP subcommand:


### PR DESCRIPTION
Hello,

While reading the awesome Redis documentation I stumbled on what I thought was a typo in an example (DELCONSUMER). Instead of just fixing I thought it would be better for understanding to always use the same groupname on that page. 

Checking the other examples I actually stumbled on a bigger issue; the command header seem to miss the groupname when using SETID. From the source it actually appears to be required here (cf first commit). 

Anyway feel free to close if you actually wanted different group name in the examples but I believe the SETID part is actually an error.

Thanks again for this amazing project & piece of software! :tada: 

PS: This issue is also present in https://github.com/antirez/redis/blob/ad78b50f62c88b6396c5ee86cda89fc2313f77af/src/help.h#L1007 which seems to be autogenerated.