### PR TITLE
XREADGROUP ignores BLOCK and NOACK

### DIFF
--- a/commands/xreadgroup.md
+++ b/commands/xreadgroup.md
@@ -54,6 +54,7 @@ be one of the following two:
 
 * The special `>` ID, which means that the consumer want to receive only messages that were *never delivered to any other consumer*. It just means, give me new messages.
 * Any other ID, that is, 0 or any other valid ID or incomplete ID (just the millisecond time part), will have the effect of returning entries that are pending for the consumer sending the command. So basically if the ID is not `>`, then the command will just let the client access its pending entries: delivered to it, but not yet acknowledged.
+Notice: in this case both BLOCK and NOACK are ignored
 
 Like `XREAD` the `XREADGROUP` command can be used in a blocking way. There
 are no differences in this regard.


### PR DESCRIPTION
XREADGROUP ignores BLOCK and NOACK when specific ID is used