### PR TITLE
Update project url of the radix go redis client

### DIFF
--- a/clients.json
+++ b/clients.json
@@ -106,7 +106,7 @@
   {
     "name": "Radix",
     "language": "Go",
-    "repository": "https://github.com/mediocregopher/radix.v2",
+    "repository": "https://github.com/mediocregopher/radix",
     "description": "MIT licensed Redis client which supports pipelining, pooling, redis cluster, scripting, pub/sub, scanning, and more.",
     "authors": ["fzzbt", "mediocre_gopher"],
     "recommended": true,


### PR DESCRIPTION
After a few years of design and testing, with lots of feedback from
people testing it, I'm ready to say that the newest version of radix is
ready to be used. This version is faster and more flexible, and is
better able to handle new features like streams and RESP3.

Due to go's new module dependency system, this will be the last time the
url of the project needs to change due to a major version change.