### PR TITLE
Clarifies ZADD's return of nil with XX or NX

### DIFF
--- a/commands/zadd.md
+++ b/commands/zadd.md
@@ -58,12 +58,12 @@ If the user inserts all the elements in a sorted set with the same score (for ex
 
 @integer-reply, specifically:
 
-* The number of elements added to the sorted sets, not including elements
+* The number of elements added to the sorted set, not including elements
   already existing for which the score was updated.
 
 If the `INCR` option is specified, the return value will be @bulk-string-reply:
 
-* the new score of `member` (a double precision floating point number), represented as string.
+* The new score of `member` (a double precision floating point number) represented as string, or `nil` if the operation was aborted (when called with either the `XX` or the `NX` option).
 
 @history
 


### PR DESCRIPTION
See: https://github.com/andymccurdy/redis-py/issues/1084