### PR TITLE
Update link to deprecated redsync.go repository

### DIFF
--- a/topics/distlock.md
+++ b/topics/distlock.md
@@ -29,7 +29,7 @@ already available that can be used for reference.
 * [Redlock-php](https://github.com/ronnylt/redlock-php) (PHP implementation).
 * [PHPRedisMutex](https://github.com/malkusch/lock#phpredismutex) (further PHP implementation)
 * [cheprasov/php-redis-lock](https://github.com/cheprasov/php-redis-lock) (PHP library for locks)
-* [Redsync.go](https://github.com/hjr265/redsync.go) (Go implementation).
+* [Redsync](https://github.com/go-redsync/redsync) (Go implementation).
 * [Redisson](https://github.com/mrniko/redisson) (Java implementation).
 * [Redis::DistLock](https://github.com/sbertrang/redis-distlock) (Perl implementation).
 * [Redlock-cpp](https://github.com/jacket-code/redlock-cpp) (C++ implementation).


### PR DESCRIPTION
https://github.com/hjr265/redsync.go is now deprecated and replaced by https://github.com/go-redsync/redsync.