### PR TITLE
Add Go's RedisPipe

### DIFF
--- a/clients.json
+++ b/clients.json
@@ -129,7 +129,6 @@
     "repository": "https://github.com/joomcode/redispipe",
     "description": "RedisPipe is the high-throughput Go client with implicit pipelining and robust Cluster support.",
     "authors": ["funny_falcon"],
-    "recommended": true,
     "active": true
   },
 

--- a/clients.json
+++ b/clients.json
@@ -122,6 +122,16 @@
     "recommended": true,
     "active": true
   },
+  
+  {
+    "name": "RedisPipe",
+    "language": "Go",
+    "repository": "https://github.com/joomcode/redispipe",
+    "description": "RedisPipe is the high-throughput Go client with implicit pipelining and robust Cluster support.",
+    "authors": ["funny_falcon"],
+    "recommended": true,
+    "active": true
+  },
 
   {
     "name": "Tideland Go Redis Client",


### PR DESCRIPTION
Add link to RedisPipe - Go's client with implicit pipelining.
Note: I've copied `"recommended": true` mark since there no rules about it, and I personally will recommend it :-)