### PR TITLE
update msetnx example to make it obvious that no partial updates are made

### DIFF
--- a/commands/msetnx.md
+++ b/commands/msetnx.md
@@ -21,6 +21,6 @@ others are unchanged.
 
 ```cli
 MSETNX key1 "Hello" key2 "there"
-MSETNX key2 "there" key3 "world"
+MSETNX key2 "new" key3 "world"
 MGET key1 key2 key3
 ```


### PR DESCRIPTION
In the example, both the first (successful) and second (unsuccessful) command attempt to set key `key2` to value `there`. It's not obvious from the example that it's the first "there" that's responsible for `key2` having a value of "there", and not the second "there".

This minor change makes it obvious where the value "there" comes from.