### PR TITLE
Cpp Redis Repository

### DIFF
--- a/clients.json
+++ b/clients.json
@@ -1353,7 +1353,7 @@
   {
     "name": "cpp_redis",
     "language": "C++",
-    "repository": "https://github.com/cylix/cpp_redis",
+    "repository": "https://github.com/cpp-redis/cpp_redis",
     "description": "C++11 Lightweight Redis client: async, thread-safe, no dependency, pipelining, multi-platform.",
     "authors": ["simon_ninon"],
     "active": true


### PR DESCRIPTION
Simon is no longer maintaining cpp_redis. I am maintaining and providing updates for Redis 5 in [this fork](https://github.com/cpp-redis/cpp_redis).

For verification, please view the README at [https://github.com/Cylix/cpp_redis](https://github.com/Cylix/cpp_redis) with a link to my fork.