### PR TITLE
Clarify that JUSTID option doesn't increment delivery count

### DIFF
--- a/commands/xclaim.md
+++ b/commands/xclaim.md
@@ -12,10 +12,7 @@ This dynamic is clearly explained in the [Stream intro documentation](/topics/st
 
 Note that the message is claimed only if its idle time is greater the minimum idle time we specify when calling `XCLAIM`. Because as a side effect `XCLAIM` will also reset the idle time (since this is a new attempt at processing the message), two consumers trying to claim a message at the same time will never both succeed: only one will successfully claim the message. This avoids that we process a given message multiple times in a trivial way (yet multiple processing is possible and unavoidable in the general case).
 
-Moreover, as a side effect, `XCLAIM` will increment the count of attempted
-deliveries of the message. In this way messages that cannot be processed for
-some reason, for instance because the consumers crash attempting to process
-them, will start to have a larger counter and can be detected inside the system.
+Moreover, as a side effect, `XCLAIM` will increment the count of attempted deliveries of the message unless the `JUSTID` option has been specified (which only delivers the message ID, not the message itself). In this way messages that cannot be processed for some reason, for instance because the consumers crash attempting to process them, will start to have a larger counter and can be detected inside the system.
 
 ## Command options
 
@@ -28,7 +25,7 @@ useful to normal users:
 2. `TIME <ms-unix-time>`: This is the same as IDLE but instead of a relative amount of milliseconds, it sets the idle time to a specific Unix time (in milliseconds). This is useful in order to rewrite the AOF file generating `XCLAIM` commands.
 3. `RETRYCOUNT <count>`: Set the retry counter to the specified value. This counter is incremented every time a message is delivered again. Normally `XCLAIM` does not alter this counter, which is just served to clients when the XPENDING command is called: this way clients can detect anomalies, like messages that are never processed for some reason after a big number of delivery attempts.
 4. `FORCE`: Creates the pending message entry in the PEL even if certain specified IDs are not already in the PEL assigned to a different client. However the message must be exist in the stream, otherwise the IDs of non existing messages are ignored.
-5. `JUSTID`: Return just an array of IDs of messages successfully claimed, without returning the actual message.
+5. `JUSTID`: Return just an array of IDs of messages successfully claimed, without returning the actual message. Using this option means the retry counter is not incremented.
 
 @return
 


### PR DESCRIPTION
See antirez/redis#5194 for discussion on `JUSTID` semantics. Goes hand in hand with antirez/redis#5907 which embodies this logic.