### PR TITLE
Remove “abc” in the example of transactions

### DIFF
--- a/topics/transactions.md
+++ b/topics/transactions.md
@@ -86,7 +86,6 @@ command will fail when executed even if the syntax is right:
     MULTI
     +OK
     SET a 3
-    abc
     +QUEUED
     LPOP a
     +QUEUED

--- a/topics/transactions.md
+++ b/topics/transactions.md
@@ -85,7 +85,7 @@ command will fail when executed even if the syntax is right:
     Escape character is '^]'.
     MULTI
     +OK
-    SET a 3
+    SET a abc
     +QUEUED
     LPOP a
     +QUEUED


### PR DESCRIPTION
I think this "abc" is written by mistake?