### PR TITLE
Remove the link to cyber-squatted lloogg.com

### DIFF
--- a/topics/faq.md
+++ b/topics/faq.md
@@ -171,7 +171,7 @@ It means REmote DIctionary Server.
 
 Originally Redis was started in order to scale [LLOOGG][lloogg]. But after I got the basic server working I liked the idea to share the work with other people, and Redis was turned into an open source project.
 
-[lloogg]: http://lloogg.com
+[lloogg]: https://github.com/antirez/lloogg/
 
 ## How is Redis pronounced?
 


### PR DESCRIPTION
lloogg.com was cyber-squatted by some frauds.
I would remove the links to the lost domain name to reduce any possible damage for the audience. Except for just ads that guys are trying to push you to install some Chrome Extension which looks like malware.
I also created an issue here — https://github.com/antirez/lloogg/issues/7