### PR TITLE
Fix typo for the size of an integer in the Bitfield documentation

### DIFF
--- a/commands/bitfield.md
+++ b/commands/bitfield.md
@@ -4,7 +4,7 @@ The command treats a Redis string as a array of bits, and is capable of addressi
 
 For example the following command increments an 8 bit signed integer at bit offset 100, and gets the value of the 4 bit unsigned integer at bit offset 0:
 
-    > BITFIELD mykey INCRBY i5 100 1 GET u4 0
+    > BITFIELD mykey INCRBY i8 100 1 GET u4 0
     1) (integer) 1
     2) (integer) 0
 


### PR DESCRIPTION
This typo had me very confused until I realized it was a typo and not the actual command.