### PR TITLE
Remove unintended/unsafe link

### DIFF
--- a/topics/faq.md
+++ b/topics/faq.md
@@ -171,7 +171,7 @@ It means REmote DIctionary Server.
 
 Originally Redis was started in order to scale [LLOOGG][lloogg]. But after I got the basic server working I liked the idea to share the work with other people, and Redis was turned into an open source project.
 
-[lloogg]: http://lloogg.com
+[lloogg]: https://web.archive.org/web/20101129105951/http://www.lloogg.com/
 
 ## How is Redis pronounced?
 


### PR DESCRIPTION
`lloogg.com` is no longer what it once was.

---

Perusing this page, I mindlessly clicked that link to `lloogg.com`, but was surprised that the domain has been sniped by someone trying to get me to install a shady "Safe Browsing" Chrome extension.

Otherwise, a fun read, thanks!