### PR TITLE
Fix a broken link

### DIFF
--- a/topics/faq.md
+++ b/topics/faq.md
@@ -111,11 +111,10 @@ more optimistic allocation fashion, and this is indeed what you want for Redis.
 A good source to understand how Linux Virtual Memory works and other
 alternatives for `overcommit_memory` and `overcommit_ratio` is this classic
 from Red Hat Magazine, ["Understanding Virtual Memory"][redhatvm].
-Beware, this article had `1` and `2` configuration values for `overcommit_memory`
-reversed: refer to the [proc(5)][proc5] man page for the right meaning of the
+You can also refer to the [proc(5)][proc5] man page for explanations of the
 available values.
 
-[redhatvm]: http://www.redhat.com/magazine/001nov04/features/vm/
+[redhatvm]: https://people.redhat.com/nhorman/papers/rhel3_vm.pdf
 [proc5]: http://man7.org/linux/man-pages/man5/proc.5.html
 
 ## Are Redis on-disk-snapshots atomic?


### PR DESCRIPTION
Hello,

This pull request simply fixes a broken link in the FAQ.

The article is no longer available so let's fix the link to a reworked version of it.

Also, the 1 and 2 values are no longer swapped in this article but let's keep a link to the `proc` man page as it can be useful and simpler than the whole article (here's the [original article](http://web.archive.org/web/20120608085846/http://www.redhat.com/magazine/001nov04/features/vm/) that wrongly explains the 1 and 2 values).

Have a nice day.