### PR TITLE
Fix typo in BZPOPMIN example

### DIFF
--- a/commands/bzpopmin.md
+++ b/commands/bzpopmin.md
@@ -31,7 +31,7 @@ redis> DEL zset1 zset2
 redis> ZADD zset1 0 a 1 b 2 c
 (integer) 3
 redis> BZPOPMIN zset1 zset2 0
-1) "zet1"
+1) "zset1"
 2) "0"
 2) "a"
 ```


### PR DESCRIPTION
The BZPOPMIN example creates a set named "zset1" but shows the returned value from BZPOPMIN as "zet1".