### PR TITLE
update list command complexity and nomenclature

### DIFF
--- a/commands.json
+++ b/commands.json
@@ -171,7 +171,7 @@
     "group": "list"
   },
   "BRPOPLPUSH": {
-    "summary": "Pop a value from a list, push it to another list and return it; or block until one is available",
+    "summary": "Pop an element from a list, push it to another list and return it; or block until one is available",
     "complexity": "O(1)",
     "arguments": [
       {
@@ -1481,7 +1481,7 @@
         "type": "string"
       },
       {
-        "name": "value",
+        "name": "element",
         "type": "string"
       }
     ],
@@ -1513,15 +1513,15 @@
     "group": "list"
   },
   "LPUSH": {
-    "summary": "Prepend one or multiple values to a list",
-    "complexity": "O(1)",
+    "summary": "Prepend one or multiple elements to a list",
+    "complexity": "O(1) for each element added, so O(N) to add N elements when the command is called with multiple arguments.",
     "arguments": [
       {
         "name": "key",
         "type": "key"
       },
       {
-        "name": "value",
+        "name": "element",
         "type": "string",
         "multiple": true
       }
@@ -1530,15 +1530,15 @@
     "group": "list"
   },
   "LPUSHX": {
-    "summary": "Prepend a value to a list, only if the list exists",
-    "complexity": "O(1)",
+    "summary": "Prepend an element to a list, only if the list exists",
+    "complexity": "O(1) for each element added, so O(N) to add N elements when the command is called with multiple arguments.",
     "arguments": [
       {
         "name": "key",
         "type": "key"
       },
       {
-        "name": "value",
+        "name": "element",
         "type": "string"
       }
     ],
@@ -2135,15 +2135,15 @@
     "group": "list"
   },
   "RPUSH": {
-    "summary": "Append one or multiple values to a list",
-    "complexity": "O(1)",
+    "summary": "Append one or multiple elements to a list",
+    "complexity": "O(1) for each element added, so O(N) to add N elements when the command is called with multiple arguments.",
     "arguments": [
       {
         "name": "key",
         "type": "key"
       },
       {
-        "name": "value",
+        "name": "element",
         "type": "string",
         "multiple": true
       }
@@ -2152,15 +2152,15 @@
     "group": "list"
   },
   "RPUSHX": {
-    "summary": "Append a value to a list, only if the list exists",
-    "complexity": "O(1)",
+    "summary": "Append an element to a list, only if the list exists",
+    "complexity": "O(1) for each element added, so O(N) to add N elements when the command is called with multiple arguments.",
     "arguments": [
       {
         "name": "key",
         "type": "key"
       },
       {
-        "name": "value",
+        "name": "element",
         "type": "string"
       }
     ],


### PR DESCRIPTION
- Documentation was inconsistent in used of `element` and `value` for lists. Normalized  to `element`
- Computational complexity did not account for variadic commands. 