### PR TITLE
Uses `element` instead of `value` for lists

### DIFF
--- a/commands.json
+++ b/commands.json
@@ -1535,7 +1535,7 @@
         "type": "key"
       },
       {
-        "name": "value",
+        "name": "element",
         "type": "string",
         "multiple": true
       }
@@ -1565,7 +1565,7 @@
   },
   "LREM": {
     "summary": "Remove elements from a list",
-    "complexity": "O(N) where N is the length of the list.",
+    "complexity": "O(N+M) where N is the length of the list and M is the number of elements removed.",
     "arguments": [
       {
         "name": "key",
@@ -1576,7 +1576,7 @@
         "type": "integer"
       },
       {
-        "name": "value",
+        "name": "element",
         "type": "string"
       }
     ],
@@ -1596,7 +1596,7 @@
         "type": "integer"
       },
       {
-        "name": "value",
+        "name": "element",
         "type": "string"
       }
     ],
@@ -2194,7 +2194,7 @@
         "type": "key"
       },
       {
-        "name": "value",
+        "name": "element",
         "type": "string",
         "multiple": true
       }

--- a/commands/linsert.md
+++ b/commands/linsert.md
@@ -1,4 +1,4 @@
-Inserts `value` in the list stored at `key` either before or after the reference
+Inserts `element` in the list stored at `key` either before or after the reference
 value `pivot`.
 
 When `key` does not exist, it is considered an empty list and no operation is

--- a/commands/lpush.md
+++ b/commands/lpush.md
@@ -16,7 +16,7 @@ containing `c` as first element, `b` as second element and `a` as third element.
 
 @history
 
-* `>= 2.4`: Accepts multiple `value` arguments.
+* `>= 2.4`: Accepts multiple `element` arguments.
   In Redis versions older than 2.4 it was possible to push a single value per
   command.
 

--- a/commands/lpushx.md
+++ b/commands/lpushx.md
@@ -9,7 +9,7 @@ exist.
 
 @history
 
-* `>= 4.0`: Accepts multiple `value` arguments.
+* `>= 4.0`: Accepts multiple `element` arguments.
   In Redis versions older than 4.0 it was possible to push a single value per
   command.
 

--- a/commands/lrem.md
+++ b/commands/lrem.md
@@ -1,10 +1,10 @@
-Removes the first `count` occurrences of elements equal to `value` from the list
+Removes the first `count` occurrences of elements equal to `element` from the list
 stored at `key`.
 The `count` argument influences the operation in the following ways:
 
-* `count > 0`: Remove elements equal to `value` moving from head to tail.
-* `count < 0`: Remove elements equal to `value` moving from tail to head.
-* `count = 0`: Remove all elements equal to `value`.
+* `count > 0`: Remove elements equal to `element` moving from head to tail.
+* `count < 0`: Remove elements equal to `element` moving from tail to head.
+* `count = 0`: Remove all elements equal to `element`.
 
 For example, `LREM list -2 "hello"` will remove the last two occurrences of
 `"hello"` in the list stored at `list`.

--- a/commands/lset.md
+++ b/commands/lset.md
@@ -1,4 +1,4 @@
-Sets the list element at `index` to `value`.
+Sets the list element at `index` to `element`.
 For more information on the `index` argument, see `LINDEX`.
 
 An error is returned for out of range indexes.

--- a/commands/rpush.md
+++ b/commands/rpush.md
@@ -16,7 +16,7 @@ containing `a` as first element, `b` as second element and `c` as third element.
 
 @history
 
-* `>= 2.4`: Accepts multiple `value` arguments.
+* `>= 2.4`: Accepts multiple `element` arguments.
   In Redis versions older than 2.4 it was possible to push a single value per
   command.
 

--- a/commands/rpushx.md
+++ b/commands/rpushx.md
@@ -9,7 +9,7 @@ exist.
 
 @history
 
-* `>= 4.0`: Accepts multiple `value` arguments.
+* `>= 4.0`: Accepts multiple `element` arguments.
   In Redis versions older than 4.0 it was possible to push a single value per
   command.
 


### PR DESCRIPTION
Also a small fix to `LREM`'s complexity.