### PR TITLE
Refactors latency-monitoring to subcommands

### DIFF
--- a/commands.json
+++ b/commands.json
@@ -1632,7 +1632,6 @@
     "summary": "Show helpful text about the different subcommands",
     "since": "4.0.0",
     "group": "server"
-
   },
   "MEMORY MALLOC-STATS": {
     "summary": "Show allocator internal stats",
@@ -3858,5 +3857,54 @@
     ],
     "since": "5.0.0",
     "group": "stream"
+  },
+  "LATENCY DOCTOR": {
+    "summary": "Return a human readable latency analysis report.",
+    "since": "2.8.13",
+    "group": "server"
+  },
+  "LATENCY GRAPH": {
+    "summary": "Return a latency graph for the event.",
+    "arguments": [
+      {
+        "name": "event",
+        "type": "string"
+      }
+    ],
+    "since": "2.8.13",
+    "group": "server"
+  },
+  "LATENCY HISTORY": {
+    "summary": "Return timestamp-latency samples for the event.",
+    "arguments": [
+      {
+        "name": "event",
+        "type": "string"
+      }
+    ],
+    "since": "2.8.13",
+    "group": "server"
+  },
+  "LATENCY LATEST": {
+    "summary": "Return the latest latency samples for all events.",
+    "since": "2.8.13",
+    "group": "server"
+  },
+  "LATENCY RESET": {
+    "summary": "Reset latency data for one or more events.",
+    "arguments": [
+      {
+        "name": "event",
+        "type": "string",
+        "optional": true
+      }
+    ],
+    "since": "2.8.13",
+    "group": "server"
+  },
+  "LATENCY HELP": {
+    "summary": "Show helpful text about the different subcommands.",
+    "since": "2.8.13",
+    "group": "server"
   }
 }

--- a/commands/latency-doctor.md
+++ b/commands/latency-doctor.md
@@ -1,0 +1,45 @@
+The `LATENCY DOCTOR` command reports about different latency-related issues and advises about possible remedies.
+
+This command is the most powerful analysis tool in the latency monitoring
+framework, and is able to provide additional statistical data like the average
+period between latency spikes, the median deviation, and a human-readable
+analysis of the event. For certain events, like `fork`, additional information
+is provided, like the rate at which the system forks processes.
+
+This is the output you should post in the Redis mailing list if you are
+looking for help about Latency related issues.
+
+@example
+
+```
+127.0.0.1:6379> latency doctor
+
+Dave, I have observed latency spikes in this Redis instance.
+You don't mind talking about it, do you Dave?
+
+1. command: 5 latency spikes (average 300ms, mean deviation 120ms,
+    period 73.40 sec). Worst all time event 500ms.
+
+I have a few advices for you:
+
+- Your current Slow Log configuration only logs events that are
+    slower than your configured latency monitor threshold. Please
+    use 'CONFIG SET slowlog-log-slower-than 1000'.
+- Check your Slow Log to understand what are the commands you are
+    running which are too slow to execute. Please check
+    http://redis.io/commands/slowlog for more information.
+- Deleting, expiring or evicting (because of maxmemory policy)
+    large objects is a blocking operation. If you have very large
+    objects that are often deleted, expired, or evicted, try to
+    fragment those objects into multiple smaller objects.
+```
+
+**Note:** the doctor has erratic psychological behaviors, so we recommend interacting with it carefully.
+
+For more information refer to the [Latency Monitoring Framework page][lm].
+
+[lm]: /topics/latency-monitor
+
+@return
+
+@bulk-string-reply

--- a/commands/latency-graph.md
+++ b/commands/latency-graph.md
@@ -1,0 +1,64 @@
+Produces an ASCII-art style graph for the specified event.
+
+`LATENCY GRAPH` lets you intuitively understand the latency trend of an `event` via state-of-the-art visualization. It can be used for quickly grasping the situation before resorting to means such parsing the raw data from `LATENCY HISTORY` or external tooling.
+
+Valid values for `event` are:
+* `active-defrag-cycle`
+* `aof-fsync-always`
+* `aof-stat`
+* `aof-rewrite-diff-write`
+* `aof-rename`
+* `aof-write`
+* `aof-write-active-child`
+* `aof-write-alone`
+* `aof-write-pending-fsync`
+* `command`
+* `expire-cycle`
+* `eviction-cycle`
+* `eviction-del`
+* `fast-command`
+* `fork`
+* `rdb-unlink-temp-file`
+
+@example
+
+```
+127.0.0.1:6379> latency reset command
+(integer) 0
+127.0.0.1:6379> debug sleep .1
+OK
+127.0.0.1:6379> debug sleep .2
+OK
+127.0.0.1:6379> debug sleep .3
+OK
+127.0.0.1:6379> debug sleep .5
+OK
+127.0.0.1:6379> debug sleep .4
+OK
+127.0.0.1:6379> latency graph command
+command - high 500 ms, low 101 ms (all time high 500 ms)
+--------------------------------------------------------------------------------
+   #_
+  _||
+ _|||
+_||||
+
+11186
+542ss
+sss
+```
+
+The vertical labels under each graph column represent the amount of seconds,
+minutes, hours or days ago the event happened. For example "15s" means that the
+first graphed event happened 15 seconds ago.
+
+The graph is normalized in the min-max scale so that the zero (the underscore
+in the lower row) is the minimum, and a # in the higher row is the maximum.
+
+For more information refer to the [Latency Monitoring Framework page][lm].
+
+[lm]: /topics/latency-monitor
+
+@return
+
+@bulk-string-reply

--- a/commands/latency-help.md
+++ b/commands/latency-help.md
@@ -1,0 +1,10 @@
+The `LATENCY HELP` command returns a helpful text describing the different
+subcommands.
+
+For more information refer to the [Latency Monitoring Framework page][lm].
+
+[lm]: /topics/latency-monitor
+
+@return
+
+@array-reply: a list of subcommands and their descriptions

--- a/commands/latency-history.md
+++ b/commands/latency-history.md
@@ -1,0 +1,44 @@
+The `LATENCY HISTORY` command returns the raw data of the `event`'s latency spikes time series.
+
+This is useful to an application that wants to fetch raw data in order to perform monitoring, display graphs, and so forth.
+
+The command will return up to 160 timestamp-latency pairs for the `event`.
+
+Valid values for `event` are:
+* `active-defrag-cycle`
+* `aof-fsync-always`
+* `aof-stat`
+* `aof-rewrite-diff-write`
+* `aof-rename`
+* `aof-write`
+* `aof-write-active-child`
+* `aof-write-alone`
+* `aof-write-pending-fsync`
+* `command`
+* `expire-cycle`
+* `eviction-cycle`
+* `eviction-del`
+* `fast-command`
+* `fork`
+* `rdb-unlink-temp-file`
+
+@example
+
+```
+127.0.0.1:6379> latency history command
+1) 1) (integer) 1405067822
+   2) (integer) 251
+2) 1) (integer) 1405067941
+   2) (integer) 1001
+```
+
+For more information refer to the [Latency Monitoring Framework page][lm].
+
+[lm]: /topics/latency-monitor
+
+@return
+
+@array-reply: specifically:
+
+The command returns an array where each element is a two elements array
+representing the timestamp and the latency of the event.

--- a/commands/latency-latest.md
+++ b/commands/latency-latest.md
@@ -1,0 +1,37 @@
+The `LATENCY LATEST` command reports the latest latency events logged.
+
+Each reported event has the following fields:
+
+* Event name.
+* Unix timestamp of the latest latency spike for the event.
+* Latest event latency in millisecond.
+* All-time maximum latency for this event.
+
+"All-time" means the maximum latency since the Redis instance was
+started, or the time that events were reset `LATENCY RESET`.
+
+@example:
+
+```
+127.0.0.1:6379> debug sleep 1
+OK
+(1.00s)
+127.0.0.1:6379> debug sleep .25
+OK
+127.0.0.1:6379> latency latest
+1) 1) "command"
+   2) (integer) 1405067976
+   3) (integer) 251
+   4) (integer) 1001
+```
+
+For more information refer to the [Latency Monitoring Framework page][lm].
+
+[lm]: /topics/latency-monitor
+
+@return
+
+@array-reply: specifically:
+
+The command returns an array where each element is a four elements array
+representing the event's name, timestamp, latest and all-time latency measurements.

--- a/commands/latency-reset.md
+++ b/commands/latency-reset.md
@@ -1,0 +1,34 @@
+The `LATENCY RESET` command resets the latency spikes time series of all, or only some, events.
+
+When the command is called without arguments, it resets all the
+events, discarding the currently logged latency spike events, and resetting
+the maximum event time register.
+
+It is possible to reset only specific events by providing the `event` names
+as arguments.
+
+Valid values for `event` are:
+* `active-defrag-cycle`
+* `aof-fsync-always`
+* `aof-stat`
+* `aof-rewrite-diff-write`
+* `aof-rename`
+* `aof-write`
+* `aof-write-active-child`
+* `aof-write-alone`
+* `aof-write-pending-fsync`
+* `command`
+* `expire-cycle`
+* `eviction-cycle`
+* `eviction-del`
+* `fast-command`
+* `fork`
+* `rdb-unlink-temp-file`
+
+For more information refer to the [Latency Monitoring Framework page][lm].
+
+[lm]: /topics/latency-monitor
+
+@reply
+
+@integer-reply: the number of event time series that were reset.


### PR DESCRIPTION
Fixes #821 

This PR includes:
* Minor edits
* Breakdown of latency-monitor.md to subcommand .md files
* Documentation of all event names and their meanings