### PR TITLE
Add Rediseen to tools.json

### DIFF
--- a/tools.json
+++ b/tools.json
@@ -669,5 +669,14 @@
     "description": "A Terminal Client for Redis with AutoCompletion and Syntax Highlighting.",
     "url": "https://iredis.io",
     "authors": ["laixintao"]
+  },
+  
+    {
+    "name": "Rediseen",
+    "language": "Go",
+    "repository": "https://github.com/XD-DENG/rediseen",
+    "description": "Start a REST-like API service for your Redis database, without writing a single line of code.",
+    "url": "https://github.com/XD-DENG/rediseen",
+    "authors": ["Xiaodong DENG"]
   }
 ]

--- a/tools.json
+++ b/tools.json
@@ -677,6 +677,6 @@
     "repository": "https://github.com/XD-DENG/rediseen",
     "description": "Start a REST-like API service for your Redis database, without writing a single line of code.",
     "url": "https://github.com/XD-DENG/rediseen",
-    "authors": ["Xiaodong DENG"]
+    "authors": ["XiaodongDENG1"]
   }
 ]


### PR DESCRIPTION
Rediseen is a tool helping start REST-like API service for your Redis database, without writing a single line of code.