### PR TITLE
Reference module documentation pages rather than files from intro page

### DIFF
--- a/topics/modules-intro.md
+++ b/topics/modules-intro.md
@@ -1,12 +1,12 @@
 Redis Modules: an introduction to the API
 ===
 
-The modules documentation is composed of the following files:
+The modules documentation is composed of the following pages:
 
-* `INTRO.md` (this file). An overview about Redis Modules system and API. It's a good idea to start your reading here.
-* `API.md` is generated from module.c top comments of RedisModule functions. It is a good reference in order to understand how each function works.
-* `TYPES.md` covers the implementation of native data types into modules.
-* `BLOCK.md` shows how to write blocking commands that will not reply immediately, but will block the client, without blocking the Redis server, and will provide a reply whenever will be possible.
+* Introduction to Redis modules (this file). An overview about Redis Modules system and API. It's a good idea to start your reading here.
+* [Redis modules API reference](/topics/modules-api-ref) is generated from module.c top comments of RedisModule functions. It is a good reference in order to understand how each function works.
+* [Implementing native data types](/topics/modules-native-types) covers the implementation of native data types into modules.
+* [Blocking operations](/topics/modules-blocking-ops) shows how to write blocking commands that will not reply immediately, but will block the client, without blocking the Redis server, and will provide a reply whenever will be possible.
 
 Redis modules make possible to extend Redis functionality using external
 modules, implementing new Redis commands at a speed and with features

--- a/topics/modules-intro.md
+++ b/topics/modules-intro.md
@@ -4,9 +4,9 @@ Redis Modules: an introduction to the API
 The modules documentation is composed of the following pages:
 
 * Introduction to Redis modules (this file). An overview about Redis Modules system and API. It's a good idea to start your reading here.
-* [Redis modules API reference](/topics/modules-api-ref) is generated from module.c top comments of RedisModule functions. It is a good reference in order to understand how each function works.
 * [Implementing native data types](/topics/modules-native-types) covers the implementation of native data types into modules.
 * [Blocking operations](/topics/modules-blocking-ops) shows how to write blocking commands that will not reply immediately, but will block the client, without blocking the Redis server, and will provide a reply whenever will be possible.
+* [Redis modules API reference](/topics/modules-api-ref) is generated from module.c top comments of RedisModule functions. It is a good reference in order to understand how each function works.
 
 Redis modules make possible to extend Redis functionality using external
 modules, implementing new Redis commands at a speed and with features


### PR DESCRIPTION
## Problem

The filename references on page https://redis.io/topics/modules-intro were confusing, since it wasn't clear what repo those files were in and those filenames weren't accurate anymore.

## Solution

This PR makes that clearer by linking to pages themselves and using the same name and order for those pages as on the main Documentation page.

---

A possible future enhancement would be to turn this into a related topics section similar to the related commands section at the top of the [Pub/Sub topic](https://redis.io/topics/pubsub) page or as a sidebar like on the [PUBSUB command](https://redis.io/commands/pubsub) page.