### PR TITLE
fix minor error in eval doc

### DIFF
--- a/commands/eval.md
+++ b/commands/eval.md
@@ -609,7 +609,7 @@ new protocol using the `HELLO` command: this way the connection is put
 in RESP3 mode. In this mode certain commands, like for instance `HGETALL`,
 reply with a new data type (the Map data type in this specific case). The
 RESP3 protocol is semantically more powerful, however most scripts are ok
-with using just RESP3.
+with using just RESP2.
 
 The Lua engine always assumes to run in RESP2 mode when talking with Redis,
 so whatever the connection that is invoking the `EVAL` or `EVALSHA` command


### PR DESCRIPTION
The section 'Using Lua scripting in RESP3 mode' includes the following sentence:

The RESP3 protocol is semantically more powerful, however most scripts are ok with using just RESP3.

However, the sentence makes no sense. I suspect that it was a typo, which changes the meaning though.
The sentence is probably supposed to go like this:

The RESP3 protocol is semantically more powerful, however most scripts are ok with using just RESP2.