### PR TITLE
update commands.json ZINCRBY: change increment type to double

### DIFF
--- a/commands.json
+++ b/commands.json
@@ -2538,7 +2538,7 @@
       },
       {
         "name": "value",
-        "type": "string"
+        "type": "integer"
       }
     ],
     "since": "2.2.0",

--- a/commands.json
+++ b/commands.json
@@ -3140,7 +3140,7 @@
       },
       {
         "name": "increment",
-        "type": "integer"
+        "type": "double"
       },
       {
         "name": "member",


### PR DESCRIPTION
ZINCRBY accepts double for increment parameter - current type is integer