### PR TITLE
Adds aedis to the list of C++ redis clients.

### DIFF
--- a/clients.json
+++ b/clients.json
@@ -940,6 +940,15 @@
   },
 
   {
+    "name": "aedis",
+    "language": "C++",
+    "repository": "https://github.com/mzimbres/aedis",
+    "description": "An async redis client designed for simplicity and reliability.",
+    "authors": ["mzimbres"],
+    "active": true
+  },
+
+  {
     "name": "libredis",
     "language": "C",
     "repository": "https://github.com/toymachine/libredis",


### PR DESCRIPTION
Hi, I would like to have my C++ redis client to be listed in redis-doc. Thanks.