### PR TITLE
fix: subscribe should be of type string

### DIFF
--- a/commands.json
+++ b/commands.json
@@ -2874,12 +2874,8 @@
     "complexity": "O(N) where N is the number of channels to subscribe to.",
     "arguments": [
       {
-        "name": [
-          "channel"
-        ],
-        "type": [
-          "string"
-        ],
+        "name": "channel",
+        "type": "string",
         "multiple": true
       }
     ],


### PR DESCRIPTION
arguments for SUBSCRIBE were in the wrong format, which caused this bug: https://github.com/mmkal/handy-redis/issues/46

this change makes them match unsubscribe: https://github.com/antirez/redis-doc/blob/c882f1d3a767a096453489b00d7ec5bcc2eceaa7/commands.json#L2997-L3010