### PR TITLE
fix: revert 927

### DIFF
--- a/commands.json
+++ b/commands.json
@@ -2509,12 +2509,15 @@
         "type": "string"
       },
       {
-        "name": "expiration",
-        "type": "enum",
-        "enum": [
-          "EX seconds",
-          "PX milliseconds"
-        ],
+        "command": "EX",
+        "name": "seconds",
+        "type": "integer",
+        "optional": true
+      },
+      {
+        "command": "PX",
+        "name": "milliseconds",
+        "type": "integer",
         "optional": true
       },
       {


### PR DESCRIPTION
PR https://github.com/antirez/redis-doc/pull/927 fixed a valid issue, namely allowing nonsensical usage of `EX` and `PX` together, but the fix had a worse side-effect (IMO). By setting the type of the `expiration` argument as type `enum` with enum values `["EX seconds", "PX milliseconds"]`, this suggests to clients that the `set` command can receive an optional argument with _literal value_ `'EX seconds'` or `'PX seconds'`. In a client library I maintain which [generates types from commands.json](https://github.com/mmkal/handy-redis), this produces incorrect types. Here's a simplified diff (typescript) when updating the redis-doc submodule the client uses to latest master:

```diff
- set(key: string, value: string, seconds: ["EX", number]): Promise<string | null>;
- set(key: string, value: string, milliseconds: ["PX", number]): Promise<string | null>;
+ set(key: string, value: string, expiration: "EX seconds" | "PX milliseconds"): Promise<string | null>;
```

If the library updated to latest master, the new client would actually disallow correct usage. This was formerly a valid call:

```typescript
client.set("a:foo", "123", ["EX", 60])
```

And using latest master or redis-doc receives a compiler error, and it's actually impossible to use `EX` or `PX` without one. It only allows `client.set("a:foo": "123", "EX seconds")`.

A fix for this that didn't allow for `set foo bar EX 2 PX 200` type usage would be to allow enum types within tuples, something like:

```json
{
  "name": ["expiry", "period"],
  "type": [{ "enum": ["EX", "PX"]}, "integer"]
}
```

I would be happy to discuss adding something like that in a follow-up, but it'd be introducing a new concept, and probably requires more careful thought in order to not create confusion or inconsistency. With this PR, I'd like to just fix a bug, which is that `enum` is being used incorrectly.