### PR TITLE
feat: json-schema commands format

### DIFF
--- a/commands.json-schema.json
+++ b/commands.json-schema.json
@@ -1,0 +1,6172 @@
+{
+  "APPEND": {
+    "summary": "Append a value to a key",
+    "complexity": "O(1). The amortized time complexity is O(1) assuming the appended value is small and the already present value is of any size, since the dynamic string library used by Redis will double the free space available on every reallocation.",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "value",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
+    "since": "2.0.0",
+    "group": "string",
+    "return": {
+      "type": "integer"
+    }
+  },
+  "AUTH": {
+    "summary": "Authenticate to the server",
+    "arguments": [
+      {
+        "name": "password",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
+    "since": "1.0.0",
+    "group": "connection",
+    "return": {
+      "type": "string"
+    }
+  },
+  "BGREWRITEAOF": {
+    "summary": "Asynchronously rewrite the append-only file",
+    "since": "1.0.0",
+    "group": "server",
+    "arguments": [],
+    "return": {
+      "type": "string"
+    }
+  },
+  "BGSAVE": {
+    "summary": "Asynchronously save the dataset to disk",
+    "since": "1.0.0",
+    "group": "server",
+    "arguments": [],
+    "return": {
+      "type": "string"
+    }
+  },
+  "BITCOUNT": {
+    "summary": "Count set bits in a string",
+    "complexity": "O(N)",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "start_end",
+        "optional": true,
+        "schema": {
+          "type": "array",
+          "items": [
+            {
+              "title": "start",
+              "type": "integer"
+            },
+            {
+              "title": "end",
+              "type": "integer"
+            }
+          ]
+        }
+      }
+    ],
+    "since": "2.6.0",
+    "group": "string",
+    "return": {
+      "type": "integer"
+    }
+  },
+  "BITFIELD": {
+    "summary": "Perform arbitrary bitfield integer operations on strings",
+    "complexity": "O(1) for each subcommand specified",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "type_offset",
+        "optional": true,
+        "schema": {
+          "type": "array",
+          "items": [
+            {
+              "type": "string",
+              "enum": [
+                "GET"
+              ]
+            },
+            {
+              "title": "type",
+              "type": "string"
+            },
+            {
+              "title": "offset",
+              "type": "integer"
+            }
+          ]
+        }
+      },
+      {
+        "name": "type_offset_value",
+        "optional": true,
+        "schema": {
+          "type": "array",
+          "items": [
+            {
+              "type": "string",
+              "enum": [
+                "SET"
+              ]
+            },
+            {
+              "title": "type",
+              "type": "string"
+            },
+            {
+              "title": "offset",
+              "type": "integer"
+            },
+            {
+              "title": "value",
+              "type": "integer"
+            }
+          ]
+        }
+      },
+      {
+        "name": "type_offset_increment",
+        "optional": true,
+        "schema": {
+          "type": "array",
+          "items": [
+            {
+              "type": "string",
+              "enum": [
+                "INCRBY"
+              ]
+            },
+            {
+              "title": "type",
+              "type": "string"
+            },
+            {
+              "title": "offset",
+              "type": "integer"
+            },
+            {
+              "title": "increment",
+              "type": "integer"
+            }
+          ]
+        }
+      },
+      {
+        "optional": true,
+        "schema": {
+          "type": "string",
+          "enum": [
+            "WRAP",
+            "SAT",
+            "FAIL"
+          ]
+        }
+      }
+    ],
+    "since": "3.2.0",
+    "group": "string",
+    "return": {}
+  },
+  "BITOP": {
+    "summary": "Perform bitwise operations between strings",
+    "complexity": "O(N)",
+    "arguments": [
+      {
+        "name": "operation",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "destkey",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "key",
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    ],
+    "since": "2.6.0",
+    "group": "string",
+    "return": {
+      "type": "integer"
+    }
+  },
+  "BITPOS": {
+    "summary": "Find first bit set or clear in a string",
+    "complexity": "O(N)",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "bit",
+        "schema": {
+          "type": "integer"
+        }
+      },
+      {
+        "name": "start",
+        "optional": true,
+        "schema": {
+          "type": "integer"
+        }
+      },
+      {
+        "name": "end",
+        "optional": true,
+        "schema": {
+          "type": "integer"
+        }
+      }
+    ],
+    "since": "2.8.7",
+    "group": "string",
+    "return": {
+      "type": "integer"
+    }
+  },
+  "BLPOP": {
+    "summary": "Remove and get the first element in a list, or block until one is available",
+    "complexity": "O(1)",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      {
+        "name": "timeout",
+        "schema": {
+          "type": "integer"
+        }
+      }
+    ],
+    "since": "2.0.0",
+    "group": "list",
+    "return": {
+      "anyOf": [
+        {
+          "type": "array"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    }
+  },
+  "BRPOP": {
+    "summary": "Remove and get the last element in a list, or block until one is available",
+    "complexity": "O(1)",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      {
+        "name": "timeout",
+        "schema": {
+          "type": "integer"
+        }
+      }
+    ],
+    "since": "2.0.0",
+    "group": "list",
+    "return": {
+      "anyOf": [
+        {
+          "type": "array"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    }
+  },
+  "BRPOPLPUSH": {
+    "summary": "Pop an element from a list, push it to another list and return it; or block until one is available",
+    "complexity": "O(1)",
+    "arguments": [
+      {
+        "name": "source",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "destination",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "timeout",
+        "schema": {
+          "type": "integer"
+        }
+      }
+    ],
+    "since": "2.2.0",
+    "group": "list",
+    "return": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    }
+  },
+  "BZPOPMIN": {
+    "summary": "Remove and return the member with the lowest score from one or more sorted sets, or block until one is available",
+    "complexity": "O(log(N)) with N being the number of elements in the sorted set.",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      {
+        "name": "timeout",
+        "schema": {
+          "type": "integer"
+        }
+      }
+    ],
+    "since": "5.0.0",
+    "group": "sorted_set",
+    "return": {
+      "anyOf": [
+        {
+          "type": "array"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    }
+  },
+  "BZPOPMAX": {
+    "summary": "Remove and return the member with the highest score from one or more sorted sets, or block until one is available",
+    "complexity": "O(log(N)) with N being the number of elements in the sorted set.",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      {
+        "name": "timeout",
+        "schema": {
+          "type": "integer"
+        }
+      }
+    ],
+    "since": "5.0.0",
+    "group": "sorted_set",
+    "return": {
+      "anyOf": [
+        {
+          "type": "array"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    }
+  },
+  "CLIENT ID": {
+    "summary": "Returns the client ID for the current connection",
+    "complexity": "O(1)",
+    "since": "5.0.0",
+    "group": "server",
+    "arguments": [],
+    "return": {}
+  },
+  "CLIENT KILL": {
+    "summary": "Kill the connection of a client",
+    "complexity": "O(N) where N is the number of client connections",
+    "arguments": [
+      {
+        "name": "ip:port",
+        "optional": true,
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "client-id",
+        "optional": true,
+        "schema": {
+          "type": "integer"
+        }
+      },
+      {
+        "optional": true,
+        "schema": {
+          "type": "string",
+          "enum": [
+            "normal",
+            "master",
+            "slave",
+            "pubsub"
+          ]
+        }
+      },
+      {
+        "name": "ip:port",
+        "optional": true,
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "yes/no",
+        "optional": true,
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
+    "since": "2.4.0",
+    "group": "server",
+    "return": {}
+  },
+  "CLIENT LIST": {
+    "summary": "Get the list of client connections",
+    "complexity": "O(N) where N is the number of client connections",
+    "arguments": [
+      {
+        "optional": true,
+        "schema": {
+          "type": "string",
+          "enum": [
+            "normal",
+            "master",
+            "replica",
+            "pubsub"
+          ]
+        }
+      }
+    ],
+    "since": "2.4.0",
+    "group": "server",
+    "return": {}
+  },
+  "CLIENT GETNAME": {
+    "summary": "Get the current connection name",
+    "complexity": "O(1)",
+    "since": "2.6.9",
+    "group": "server",
+    "arguments": [],
+    "return": {}
+  },
+  "CLIENT PAUSE": {
+    "summary": "Stop processing commands from clients for some time",
+    "complexity": "O(1)",
+    "arguments": [
+      {
+        "name": "timeout",
+        "schema": {
+          "type": "integer"
+        }
+      }
+    ],
+    "since": "2.9.50",
+    "group": "server",
+    "return": {}
+  },
+  "CLIENT REPLY": {
+    "summary": "Instruct the server whether to reply to commands",
+    "complexity": "O(1)",
+    "arguments": [
+      {
+        "name": "reply-mode",
+        "schema": {
+          "type": "string",
+          "enum": [
+            "ON",
+            "OFF",
+            "SKIP"
+          ]
+        }
+      }
+    ],
+    "since": "3.2",
+    "group": "server",
+    "return": {}
+  },
+  "CLIENT SETNAME": {
+    "summary": "Set the current connection name",
+    "complexity": "O(1)",
+    "since": "2.6.9",
+    "arguments": [
+      {
+        "name": "connection-name",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
+    "group": "server",
+    "return": {}
+  },
+  "CLIENT UNBLOCK": {
+    "summary": "Unblock a client blocked in a blocking command from a different connection",
+    "complexity": "O(log N) where N is the number of client connections",
+    "arguments": [
+      {
+        "name": "client-id",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "unblock-type",
+        "optional": true,
+        "schema": {
+          "type": "string",
+          "enum": [
+            "TIMEOUT",
+            "ERROR"
+          ]
+        }
+      }
+    ],
+    "since": "5.0.0",
+    "group": "server",
+    "return": {}
+  },
+  "CLUSTER ADDSLOTS": {
+    "summary": "Assign new hash slots to receiving node",
+    "complexity": "O(N) where N is the total number of hash slot arguments",
+    "arguments": [
+      {
+        "name": "slot",
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "integer"
+          }
+        }
+      }
+    ],
+    "since": "3.0.0",
+    "group": "cluster",
+    "return": {}
+  },
+  "CLUSTER BUMPEPOCH": {
+    "summary": "Advance the cluster config epoch",
+    "complexity": "O(1)",
+    "since": "3.0.0",
+    "group": "cluster",
+    "arguments": [],
+    "return": {}
+  },
+  "CLUSTER COUNT-FAILURE-REPORTS": {
+    "summary": "Return the number of failure reports active for a given node",
+    "complexity": "O(N) where N is the number of failure reports",
+    "arguments": [
+      {
+        "name": "node-id",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
+    "since": "3.0.0",
+    "group": "cluster",
+    "return": {}
+  },
+  "CLUSTER COUNTKEYSINSLOT": {
+    "summary": "Return the number of local keys in the specified hash slot",
+    "complexity": "O(1)",
+    "arguments": [
+      {
+        "name": "slot",
+        "schema": {
+          "type": "integer"
+        }
+      }
+    ],
+    "since": "3.0.0",
+    "group": "cluster",
+    "return": {}
+  },
+  "CLUSTER DELSLOTS": {
+    "summary": "Set hash slots as unbound in receiving node",
+    "complexity": "O(N) where N is the total number of hash slot arguments",
+    "arguments": [
+      {
+        "name": "slot",
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "integer"
+          }
+        }
+      }
+    ],
+    "since": "3.0.0",
+    "group": "cluster",
+    "return": {}
+  },
+  "CLUSTER FAILOVER": {
+    "summary": "Forces a replica to perform a manual failover of its master.",
+    "complexity": "O(1)",
+    "arguments": [
+      {
+        "name": "options",
+        "optional": true,
+        "schema": {
+          "type": "string",
+          "enum": [
+            "FORCE",
+            "TAKEOVER"
+          ]
+        }
+      }
+    ],
+    "since": "3.0.0",
+    "group": "cluster",
+    "return": {}
+  },
+  "CLUSTER FLUSHSLOTS": {
+    "summary": "Delete a node's own slots information",
+    "complexity": "O(1)",
+    "since": "3.0.0",
+    "group": "cluster",
+    "arguments": [],
+    "return": {}
+  },
+  "CLUSTER FORGET": {
+    "summary": "Remove a node from the nodes table",
+    "complexity": "O(1)",
+    "arguments": [
+      {
+        "name": "node-id",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
+    "since": "3.0.0",
+    "group": "cluster",
+    "return": {}
+  },
+  "CLUSTER GETKEYSINSLOT": {
+    "summary": "Return local key names in the specified hash slot",
+    "complexity": "O(log(N)) where N is the number of requested keys",
+    "arguments": [
+      {
+        "name": "slot",
+        "schema": {
+          "type": "integer"
+        }
+      },
+      {
+        "name": "count",
+        "schema": {
+          "type": "integer"
+        }
+      }
+    ],
+    "since": "3.0.0",
+    "group": "cluster",
+    "return": {}
+  },
+  "CLUSTER INFO": {
+    "summary": "Provides info about Redis Cluster node state",
+    "complexity": "O(1)",
+    "since": "3.0.0",
+    "group": "cluster",
+    "arguments": [],
+    "return": {}
+  },
+  "CLUSTER KEYSLOT": {
+    "summary": "Returns the hash slot of the specified key",
+    "complexity": "O(N) where N is the number of bytes in the key",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
+    "since": "3.0.0",
+    "group": "cluster",
+    "return": {}
+  },
+  "CLUSTER MEET": {
+    "summary": "Force a node cluster to handshake with another node",
+    "complexity": "O(1)",
+    "arguments": [
+      {
+        "name": "ip",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "port",
+        "schema": {
+          "type": "integer"
+        }
+      }
+    ],
+    "since": "3.0.0",
+    "group": "cluster",
+    "return": {}
+  },
+  "CLUSTER MYID": {
+    "summary": "Return the node id",
+    "complexity": "O(1)",
+    "since": "3.0.0",
+    "group": "cluster",
+    "arguments": [],
+    "return": {}
+  },
+  "CLUSTER NODES": {
+    "summary": "Get Cluster config for the node",
+    "complexity": "O(N) where N is the total number of Cluster nodes",
+    "since": "3.0.0",
+    "group": "cluster",
+    "arguments": [],
+    "return": {}
+  },
+  "CLUSTER REPLICATE": {
+    "summary": "Reconfigure a node as a replica of the specified master node",
+    "complexity": "O(1)",
+    "arguments": [
+      {
+        "name": "node-id",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
+    "since": "3.0.0",
+    "group": "cluster",
+    "return": {}
+  },
+  "CLUSTER RESET": {
+    "summary": "Reset a Redis Cluster node",
+    "complexity": "O(N) where N is the number of known nodes. The command may execute a FLUSHALL as a side effect.",
+    "arguments": [
+      {
+        "name": "reset-type",
+        "optional": true,
+        "schema": {
+          "type": "string",
+          "enum": [
+            "HARD",
+            "SOFT"
+          ]
+        }
+      }
+    ],
+    "since": "3.0.0",
+    "group": "cluster",
+    "return": {}
+  },
+  "CLUSTER SAVECONFIG": {
+    "summary": "Forces the node to save cluster state on disk",
+    "complexity": "O(1)",
+    "since": "3.0.0",
+    "group": "cluster",
+    "arguments": [],
+    "return": {}
+  },
+  "CLUSTER SET-CONFIG-EPOCH": {
+    "summary": "Set the configuration epoch in a new node",
+    "complexity": "O(1)",
+    "arguments": [
+      {
+        "name": "config-epoch",
+        "schema": {
+          "type": "integer"
+        }
+      }
+    ],
+    "since": "3.0.0",
+    "group": "cluster",
+    "return": {}
+  },
+  "CLUSTER SETSLOT": {
+    "summary": "Bind a hash slot to a specific node",
+    "complexity": "O(1)",
+    "arguments": [
+      {
+        "name": "slot",
+        "schema": {
+          "type": "integer"
+        }
+      },
+      {
+        "name": "subcommand",
+        "schema": {
+          "type": "string",
+          "enum": [
+            "IMPORTING",
+            "MIGRATING",
+            "STABLE",
+            "NODE"
+          ]
+        }
+      },
+      {
+        "name": "node-id",
+        "optional": true,
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
+    "since": "3.0.0",
+    "group": "cluster",
+    "return": {}
+  },
+  "CLUSTER SLAVES": {
+    "summary": "List replica nodes of the specified master node",
+    "complexity": "O(1)",
+    "arguments": [
+      {
+        "name": "node-id",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
+    "since": "3.0.0",
+    "group": "cluster",
+    "return": {}
+  },
+  "CLUSTER REPLICAS": {
+    "summary": "List replica nodes of the specified master node",
+    "complexity": "O(1)",
+    "arguments": [
+      {
+        "name": "node-id",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
+    "since": "5.0.0",
+    "group": "cluster",
+    "return": {}
+  },
+  "CLUSTER SLOTS": {
+    "summary": "Get array of Cluster slot to node mappings",
+    "complexity": "O(N) where N is the total number of Cluster nodes",
+    "since": "3.0.0",
+    "group": "cluster",
+    "arguments": [],
+    "return": {}
+  },
+  "COMMAND": {
+    "summary": "Get array of Redis command details",
+    "complexity": "O(N) where N is the total number of Redis commands",
+    "since": "2.8.13",
+    "group": "server",
+    "arguments": [],
+    "return": {
+      "type": "array"
+    }
+  },
+  "COMMAND COUNT": {
+    "summary": "Get total number of Redis commands",
+    "complexity": "O(1)",
+    "since": "2.8.13",
+    "group": "server",
+    "arguments": [],
+    "return": {}
+  },
+  "COMMAND GETKEYS": {
+    "summary": "Extract keys given a full Redis command",
+    "complexity": "O(N) where N is the number of arguments to the command",
+    "since": "2.8.13",
+    "group": "server",
+    "arguments": [],
+    "return": {}
+  },
+  "COMMAND INFO": {
+    "summary": "Get array of specific Redis command details",
+    "complexity": "O(N) when N is number of commands to look up",
+    "since": "2.8.13",
+    "arguments": [
+      {
+        "name": "command-name",
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    ],
+    "group": "server",
+    "return": {}
+  },
+  "CONFIG GET": {
+    "summary": "Get the value of a configuration parameter",
+    "arguments": [
+      {
+        "name": "parameter",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
+    "since": "2.0.0",
+    "group": "server",
+    "return": {}
+  },
+  "CONFIG REWRITE": {
+    "summary": "Rewrite the configuration file with the in memory configuration",
+    "since": "2.8.0",
+    "group": "server",
+    "arguments": [],
+    "return": {}
+  },
+  "CONFIG SET": {
+    "summary": "Set a configuration parameter to the given value",
+    "arguments": [
+      {
+        "name": "parameter",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "value",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
+    "since": "2.0.0",
+    "group": "server",
+    "return": {}
+  },
+  "CONFIG RESETSTAT": {
+    "summary": "Reset the stats returned by INFO",
+    "complexity": "O(1)",
+    "since": "2.0.0",
+    "group": "server",
+    "arguments": [],
+    "return": {}
+  },
+  "DBSIZE": {
+    "summary": "Return the number of keys in the selected database",
+    "since": "1.0.0",
+    "group": "server",
+    "arguments": [],
+    "return": {
+      "type": "integer"
+    }
+  },
+  "DEBUG OBJECT": {
+    "summary": "Get debugging information about a key",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
+    "since": "1.0.0",
+    "group": "server",
+    "return": {}
+  },
+  "DEBUG SEGFAULT": {
+    "summary": "Make the server crash",
+    "since": "1.0.0",
+    "group": "server",
+    "arguments": [],
+    "return": {}
+  },
+  "DECR": {
+    "summary": "Decrement the integer value of a key by one",
+    "complexity": "O(1)",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
+    "since": "1.0.0",
+    "group": "string",
+    "return": {
+      "type": "integer"
+    }
+  },
+  "DECRBY": {
+    "summary": "Decrement the integer value of a key by the given number",
+    "complexity": "O(1)",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "decrement",
+        "schema": {
+          "type": "integer"
+        }
+      }
+    ],
+    "since": "1.0.0",
+    "group": "string",
+    "return": {
+      "type": "integer"
+    }
+  },
+  "DEL": {
+    "summary": "Delete a key",
+    "complexity": "O(N) where N is the number of keys that will be removed. When a key to remove holds a value other than a string, the individual complexity for this key is O(M) where M is the number of elements in the list, set, sorted set or hash. Removing a single key that holds a string value is O(1).",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    ],
+    "since": "1.0.0",
+    "group": "generic",
+    "return": {
+      "type": "integer"
+    }
+  },
+  "DISCARD": {
+    "summary": "Discard all commands issued after MULTI",
+    "since": "2.0.0",
+    "group": "transactions",
+    "arguments": [],
+    "return": {
+      "type": "string"
+    }
+  },
+  "DUMP": {
+    "summary": "Return a serialized version of the value stored at the specified key.",
+    "complexity": "O(1) to access the key and additional O(N*M) to serialized it, where N is the number of Redis objects composing the value and M their average size. For small string values the time complexity is thus O(1)+O(1*M) where M is small, so simply O(1).",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
+    "since": "2.6.0",
+    "group": "generic",
+    "return": {
+      "type": "string"
+    }
+  },
+  "ECHO": {
+    "summary": "Echo the given string",
+    "arguments": [
+      {
+        "name": "message",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
+    "since": "1.0.0",
+    "group": "connection",
+    "return": {
+      "type": "string"
+    }
+  },
+  "EVAL": {
+    "summary": "Execute a Lua script server side",
+    "complexity": "Depends on the script that is executed.",
+    "arguments": [
+      {
+        "name": "script",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "numkeys",
+        "schema": {
+          "type": "integer"
+        }
+      },
+      {
+        "name": "key",
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      {
+        "name": "arg",
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    ],
+    "since": "2.6.0",
+    "group": "scripting",
+    "return": {}
+  },
+  "EVALSHA": {
+    "summary": "Execute a Lua script server side",
+    "complexity": "Depends on the script that is executed.",
+    "arguments": [
+      {
+        "name": "sha1",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "numkeys",
+        "schema": {
+          "type": "integer"
+        }
+      },
+      {
+        "name": "key",
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      {
+        "name": "arg",
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    ],
+    "since": "2.6.0",
+    "group": "scripting",
+    "return": {}
+  },
+  "EXEC": {
+    "summary": "Execute all commands issued after MULTI",
+    "since": "1.2.0",
+    "group": "transactions",
+    "arguments": [],
+    "return": {
+      "anyOf": [
+        {
+          "type": "array"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    }
+  },
+  "EXISTS": {
+    "summary": "Determine if a key exists",
+    "complexity": "O(1)",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    ],
+    "since": "1.0.0",
+    "group": "generic",
+    "return": {
+      "type": "integer"
+    }
+  },
+  "EXPIRE": {
+    "summary": "Set a key's time to live in seconds",
+    "complexity": "O(1)",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "seconds",
+        "schema": {
+          "type": "integer"
+        }
+      }
+    ],
+    "since": "1.0.0",
+    "group": "generic",
+    "return": {
+      "type": "integer"
+    }
+  },
+  "EXPIREAT": {
+    "summary": "Set the expiration for a key as a UNIX timestamp",
+    "complexity": "O(1)",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "timestamp",
+        "schema": {}
+      }
+    ],
+    "since": "1.2.0",
+    "group": "generic",
+    "return": {
+      "type": "integer"
+    }
+  },
+  "FLUSHALL": {
+    "summary": "Remove all keys from all databases",
+    "arguments": [
+      {
+        "name": "async",
+        "optional": true,
+        "schema": {
+          "type": "string",
+          "enum": [
+            "ASYNC"
+          ]
+        }
+      }
+    ],
+    "since": "1.0.0",
+    "group": "server",
+    "return": {
+      "type": "string"
+    }
+  },
+  "FLUSHDB": {
+    "summary": "Remove all keys from the current database",
+    "arguments": [
+      {
+        "name": "async",
+        "optional": true,
+        "schema": {
+          "type": "string",
+          "enum": [
+            "ASYNC"
+          ]
+        }
+      }
+    ],
+    "since": "1.0.0",
+    "group": "server",
+    "return": {
+      "type": "string"
+    }
+  },
+  "GEOADD": {
+    "summary": "Add one or more geospatial items in the geospatial index represented using a sorted set",
+    "complexity": "O(log(N)) for each item added, where N is the number of elements in the sorted set.",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "longitude_latitude_member",
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": [
+              {
+                "title": "longitude",
+                "type": "number"
+              },
+              {
+                "title": "latitude",
+                "type": "number"
+              },
+              {
+                "title": "member",
+                "type": "string"
+              }
+            ]
+          }
+        }
+      }
+    ],
+    "since": "3.2.0",
+    "group": "geo",
+    "return": {
+      "type": "integer"
+    }
+  },
+  "GEOHASH": {
+    "summary": "Returns members of a geospatial index as standard geohash strings",
+    "complexity": "O(log(N)) for each member requested, where N is the number of elements in the sorted set.",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "member",
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    ],
+    "since": "3.2.0",
+    "group": "geo",
+    "return": {
+      "type": "array"
+    }
+  },
+  "GEOPOS": {
+    "summary": "Returns longitude and latitude of members of a geospatial index",
+    "complexity": "O(log(N)) for each member requested, where N is the number of elements in the sorted set.",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "member",
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    ],
+    "since": "3.2.0",
+    "group": "geo",
+    "return": {
+      "anyOf": [
+        {
+          "type": "array"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    }
+  },
+  "GEODIST": {
+    "summary": "Returns the distance between two members of a geospatial index",
+    "complexity": "O(log(N))",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "member1",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "member2",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "unit",
+        "optional": true,
+        "schema": {
+          "type": "string",
+          "enum": [
+            "m",
+            "km",
+            "ft",
+            "mi"
+          ]
+        }
+      }
+    ],
+    "since": "3.2.0",
+    "group": "geo",
+    "return": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    }
+  },
+  "GEORADIUS": {
+    "summary": "Query a sorted set representing a geospatial index to fetch members matching a given maximum distance from a point",
+    "complexity": "O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "longitude",
+        "schema": {
+          "type": "number"
+        }
+      },
+      {
+        "name": "latitude",
+        "schema": {
+          "type": "number"
+        }
+      },
+      {
+        "name": "radius",
+        "schema": {
+          "type": "number"
+        }
+      },
+      {
+        "name": "unit",
+        "schema": {
+          "type": "string",
+          "enum": [
+            "m",
+            "km",
+            "ft",
+            "mi"
+          ]
+        }
+      },
+      {
+        "name": "withcoord",
+        "optional": true,
+        "schema": {
+          "type": "string",
+          "enum": [
+            "WITHCOORD"
+          ]
+        }
+      },
+      {
+        "name": "withdist",
+        "optional": true,
+        "schema": {
+          "type": "string",
+          "enum": [
+            "WITHDIST"
+          ]
+        }
+      },
+      {
+        "name": "withhash",
+        "optional": true,
+        "schema": {
+          "type": "string",
+          "enum": [
+            "WITHHASH"
+          ]
+        }
+      },
+      {
+        "name": "count",
+        "optional": true,
+        "schema": {
+          "type": "integer"
+        }
+      },
+      {
+        "name": "order",
+        "optional": true,
+        "schema": {
+          "type": "string",
+          "enum": [
+            "ASC",
+            "DESC"
+          ]
+        }
+      },
+      {
+        "name": "key",
+        "optional": true,
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "key",
+        "optional": true,
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
+    "since": "3.2.0",
+    "group": "geo",
+    "return": {
+      "type": "array"
+    }
+  },
+  "GEORADIUSBYMEMBER": {
+    "summary": "Query a sorted set representing a geospatial index to fetch members matching a given maximum distance from a member",
+    "complexity": "O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "member",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "radius",
+        "schema": {
+          "type": "number"
+        }
+      },
+      {
+        "name": "unit",
+        "schema": {
+          "type": "string",
+          "enum": [
+            "m",
+            "km",
+            "ft",
+            "mi"
+          ]
+        }
+      },
+      {
+        "name": "withcoord",
+        "optional": true,
+        "schema": {
+          "type": "string",
+          "enum": [
+            "WITHCOORD"
+          ]
+        }
+      },
+      {
+        "name": "withdist",
+        "optional": true,
+        "schema": {
+          "type": "string",
+          "enum": [
+            "WITHDIST"
+          ]
+        }
+      },
+      {
+        "name": "withhash",
+        "optional": true,
+        "schema": {
+          "type": "string",
+          "enum": [
+            "WITHHASH"
+          ]
+        }
+      },
+      {
+        "name": "count",
+        "optional": true,
+        "schema": {
+          "type": "integer"
+        }
+      },
+      {
+        "name": "order",
+        "optional": true,
+        "schema": {
+          "type": "string",
+          "enum": [
+            "ASC",
+            "DESC"
+          ]
+        }
+      },
+      {
+        "name": "key",
+        "optional": true,
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "key",
+        "optional": true,
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
+    "since": "3.2.0",
+    "group": "geo",
+    "return": {}
+  },
+  "GET": {
+    "summary": "Get the value of a key",
+    "complexity": "O(1)",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
+    "since": "1.0.0",
+    "group": "string",
+    "return": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    }
+  },
+  "GETBIT": {
+    "summary": "Returns the bit value at offset in the string value stored at key",
+    "complexity": "O(1)",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "offset",
+        "schema": {
+          "type": "integer"
+        }
+      }
+    ],
+    "since": "2.2.0",
+    "group": "string",
+    "return": {
+      "type": "integer"
+    }
+  },
+  "GETRANGE": {
+    "summary": "Get a substring of the string stored at a key",
+    "complexity": "O(N) where N is the length of the returned string. The complexity is ultimately determined by the returned length, but because creating a substring from an existing string is very cheap, it can be considered O(1) for small strings.",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "start",
+        "schema": {
+          "type": "integer"
+        }
+      },
+      {
+        "name": "end",
+        "schema": {
+          "type": "integer"
+        }
+      }
+    ],
+    "since": "2.4.0",
+    "group": "string",
+    "return": {
+      "type": "string"
+    }
+  },
+  "GETSET": {
+    "summary": "Set the string value of a key and return its old value",
+    "complexity": "O(1)",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "value",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
+    "since": "1.0.0",
+    "group": "string",
+    "return": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    }
+  },
+  "HDEL": {
+    "summary": "Delete one or more hash fields",
+    "complexity": "O(N) where N is the number of fields to be removed.",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "field",
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    ],
+    "since": "2.0.0",
+    "group": "hash",
+    "return": {
+      "type": "integer"
+    }
+  },
+  "HEXISTS": {
+    "summary": "Determine if a hash field exists",
+    "complexity": "O(1)",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "field",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
+    "since": "2.0.0",
+    "group": "hash",
+    "return": {
+      "type": "integer"
+    }
+  },
+  "HGET": {
+    "summary": "Get the value of a hash field",
+    "complexity": "O(1)",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "field",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
+    "since": "2.0.0",
+    "group": "hash",
+    "return": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    }
+  },
+  "HGETALL": {
+    "summary": "Get all the fields and values in a hash",
+    "complexity": "O(N) where N is the size of the hash.",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
+    "since": "2.0.0",
+    "group": "hash",
+    "return": {
+      "type": "array"
+    }
+  },
+  "HINCRBY": {
+    "summary": "Increment the integer value of a hash field by the given number",
+    "complexity": "O(1)",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "field",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "increment",
+        "schema": {
+          "type": "integer"
+        }
+      }
+    ],
+    "since": "2.0.0",
+    "group": "hash",
+    "return": {
+      "type": "integer"
+    }
+  },
+  "HINCRBYFLOAT": {
+    "summary": "Increment the float value of a hash field by the given amount",
+    "complexity": "O(1)",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "field",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "increment",
+        "schema": {
+          "type": "number"
+        }
+      }
+    ],
+    "since": "2.6.0",
+    "group": "hash",
+    "return": {
+      "type": "string"
+    }
+  },
+  "HKEYS": {
+    "summary": "Get all the fields in a hash",
+    "complexity": "O(N) where N is the size of the hash.",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
+    "since": "2.0.0",
+    "group": "hash",
+    "return": {
+      "type": "array"
+    }
+  },
+  "HLEN": {
+    "summary": "Get the number of fields in a hash",
+    "complexity": "O(1)",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
+    "since": "2.0.0",
+    "group": "hash",
+    "return": {
+      "type": "integer"
+    }
+  },
+  "HMGET": {
+    "summary": "Get the values of all the given hash fields",
+    "complexity": "O(N) where N is the number of fields being requested.",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "field",
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    ],
+    "since": "2.0.0",
+    "group": "hash",
+    "return": {
+      "type": "array"
+    }
+  },
+  "HMSET": {
+    "summary": "Set multiple hash fields to multiple values",
+    "complexity": "O(N) where N is the number of fields being set.",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "field_value",
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": [
+              {
+                "title": "field",
+                "type": "string"
+              },
+              {
+                "title": "value",
+                "type": "string"
+              }
+            ]
+          }
+        }
+      }
+    ],
+    "since": "2.0.0",
+    "group": "hash",
+    "return": {
+      "type": "string"
+    }
+  },
+  "HSET": {
+    "summary": "Set the string value of a hash field",
+    "complexity": "O(1) for each field/value pair added, so O(N) to add N field/value pairs when the command is called with multiple field/value pairs.",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "field_value",
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": [
+              {
+                "title": "field",
+                "type": "string"
+              },
+              {
+                "title": "value",
+                "type": "string"
+              }
+            ]
+          }
+        }
+      }
+    ],
+    "since": "2.0.0",
+    "group": "hash",
+    "return": {
+      "type": "integer"
+    }
+  },
+  "HSETNX": {
+    "summary": "Set the value of a hash field, only if the field does not exist",
+    "complexity": "O(1)",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "field",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "value",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
+    "since": "2.0.0",
+    "group": "hash",
+    "return": {
+      "type": "integer"
+    }
+  },
+  "HSTRLEN": {
+    "summary": "Get the length of the value of a hash field",
+    "complexity": "O(1)",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "field",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
+    "since": "3.2.0",
+    "group": "hash",
+    "return": {
+      "type": "integer"
+    }
+  },
+  "HVALS": {
+    "summary": "Get all the values in a hash",
+    "complexity": "O(N) where N is the size of the hash.",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
+    "since": "2.0.0",
+    "group": "hash",
+    "return": {
+      "type": "array"
+    }
+  },
+  "INCR": {
+    "summary": "Increment the integer value of a key by one",
+    "complexity": "O(1)",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
+    "since": "1.0.0",
+    "group": "string",
+    "return": {
+      "type": "integer"
+    }
+  },
+  "INCRBY": {
+    "summary": "Increment the integer value of a key by the given amount",
+    "complexity": "O(1)",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "increment",
+        "schema": {
+          "type": "integer"
+        }
+      }
+    ],
+    "since": "1.0.0",
+    "group": "string",
+    "return": {
+      "type": "integer"
+    }
+  },
+  "INCRBYFLOAT": {
+    "summary": "Increment the float value of a key by the given amount",
+    "complexity": "O(1)",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "increment",
+        "schema": {
+          "type": "number"
+        }
+      }
+    ],
+    "since": "2.6.0",
+    "group": "string",
+    "return": {
+      "type": "string"
+    }
+  },
+  "INFO": {
+    "summary": "Get information and statistics about the server",
+    "arguments": [
+      {
+        "name": "section",
+        "optional": true,
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
+    "since": "1.0.0",
+    "group": "server",
+    "return": {
+      "type": "string"
+    }
+  },
+  "LOLWUT": {
+    "summary": "Display some computer art and the Redis version",
+    "arguments": [
+      {
+        "name": "version",
+        "optional": true,
+        "schema": {
+          "type": "integer"
+        }
+      }
+    ],
+    "since": "5.0.0",
+    "group": "server",
+    "return": {
+      "type": "string"
+    }
+  },
+  "KEYS": {
+    "summary": "Find all keys matching the given pattern",
+    "complexity": "O(N) with N being the number of keys in the database, under the assumption that the key names in the database and the given pattern have limited length.",
+    "arguments": [
+      {
+        "name": "pattern",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
+    "since": "1.0.0",
+    "group": "generic",
+    "return": {
+      "type": "array"
+    }
+  },
+  "LASTSAVE": {
+    "summary": "Get the UNIX time stamp of the last successful save to disk",
+    "since": "1.0.0",
+    "group": "server",
+    "arguments": [],
+    "return": {
+      "type": "integer"
+    }
+  },
+  "LINDEX": {
+    "summary": "Get an element from a list by its index",
+    "complexity": "O(N) where N is the number of elements to traverse to get to the element at index. This makes asking for the first or the last element of the list O(1).",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "index",
+        "schema": {
+          "type": "integer"
+        }
+      }
+    ],
+    "since": "1.0.0",
+    "group": "list",
+    "return": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    }
+  },
+  "LINSERT": {
+    "summary": "Insert an element before or after another element in a list",
+    "complexity": "O(N) where N is the number of elements to traverse before seeing the value pivot. This means that inserting somewhere on the left end on the list (head) can be considered O(1) and inserting somewhere on the right end (tail) is O(N).",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "where",
+        "schema": {
+          "type": "string",
+          "enum": [
+            "BEFORE",
+            "AFTER"
+          ]
+        }
+      },
+      {
+        "name": "pivot",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "element",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
+    "since": "2.2.0",
+    "group": "list",
+    "return": {
+      "type": "integer"
+    }
+  },
+  "LLEN": {
+    "summary": "Get the length of a list",
+    "complexity": "O(1)",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
+    "since": "1.0.0",
+    "group": "list",
+    "return": {
+      "type": "integer"
+    }
+  },
+  "LPOP": {
+    "summary": "Remove and get the first element in a list",
+    "complexity": "O(1)",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
+    "since": "1.0.0",
+    "group": "list",
+    "return": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    }
+  },
+  "LPUSH": {
+    "summary": "Prepend one or multiple elements to a list",
+    "complexity": "O(1) for each element added, so O(N) to add N elements when the command is called with multiple arguments.",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "element",
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    ],
+    "since": "1.0.0",
+    "group": "list",
+    "return": {
+      "type": "integer"
+    }
+  },
+  "LPUSHX": {
+    "summary": "Prepend an element to a list, only if the list exists",
+    "complexity": "O(1) for each element added, so O(N) to add N elements when the command is called with multiple arguments.",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "element",
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    ],
+    "since": "2.2.0",
+    "group": "list",
+    "return": {
+      "type": "integer"
+    }
+  },
+  "LRANGE": {
+    "summary": "Get a range of elements from a list",
+    "complexity": "O(S+N) where S is the distance of start offset from HEAD for small lists, from nearest end (HEAD or TAIL) for large lists; and N is the number of elements in the specified range.",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "start",
+        "schema": {
+          "type": "integer"
+        }
+      },
+      {
+        "name": "stop",
+        "schema": {
+          "type": "integer"
+        }
+      }
+    ],
+    "since": "1.0.0",
+    "group": "list",
+    "return": {
+      "type": "array"
+    }
+  },
+  "LREM": {
+    "summary": "Remove elements from a list",
+    "complexity": "O(N+M) where N is the length of the list and M is the number of elements removed.",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "count",
+        "schema": {
+          "type": "integer"
+        }
+      },
+      {
+        "name": "element",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
+    "since": "1.0.0",
+    "group": "list",
+    "return": {
+      "type": "integer"
+    }
+  },
+  "LSET": {
+    "summary": "Set the value of an element in a list by its index",
+    "complexity": "O(N) where N is the length of the list. Setting either the first or the last element of the list is O(1).",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "index",
+        "schema": {
+          "type": "integer"
+        }
+      },
+      {
+        "name": "element",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
+    "since": "1.0.0",
+    "group": "list",
+    "return": {
+      "type": "string"
+    }
+  },
+  "LTRIM": {
+    "summary": "Trim a list to the specified range",
+    "complexity": "O(N) where N is the number of elements to be removed by the operation.",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "start",
+        "schema": {
+          "type": "integer"
+        }
+      },
+      {
+        "name": "stop",
+        "schema": {
+          "type": "integer"
+        }
+      }
+    ],
+    "since": "1.0.0",
+    "group": "list",
+    "return": {
+      "type": "string"
+    }
+  },
+  "MEMORY DOCTOR": {
+    "summary": "Outputs memory problems report",
+    "since": "4.0.0",
+    "group": "server",
+    "arguments": [],
+    "return": {}
+  },
+  "MEMORY HELP": {
+    "summary": "Show helpful text about the different subcommands",
+    "since": "4.0.0",
+    "group": "server",
+    "arguments": [],
+    "return": {}
+  },
+  "MEMORY MALLOC-STATS": {
+    "summary": "Show allocator internal stats",
+    "since": "4.0.0",
+    "group": "server",
+    "arguments": [],
+    "return": {}
+  },
+  "MEMORY PURGE": {
+    "summary": "Ask the allocator to release memory",
+    "since": "4.0.0",
+    "group": "server",
+    "arguments": [],
+    "return": {}
+  },
+  "MEMORY STATS": {
+    "summary": "Show memory usage details",
+    "since": "4.0.0",
+    "group": "server",
+    "arguments": [],
+    "return": {}
+  },
+  "MEMORY USAGE": {
+    "summary": "Estimate the memory usage of a key",
+    "complexity": "O(N) where N is the number of samples.",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "count",
+        "optional": true,
+        "schema": {
+          "type": "integer"
+        }
+      }
+    ],
+    "since": "4.0.0",
+    "group": "server",
+    "return": {}
+  },
+  "MGET": {
+    "summary": "Get the values of all the given keys",
+    "complexity": "O(N) where N is the number of keys to retrieve.",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    ],
+    "since": "1.0.0",
+    "group": "string",
+    "return": {
+      "type": "array"
+    }
+  },
+  "MIGRATE": {
+    "summary": "Atomically transfer a key from a Redis instance to another one.",
+    "complexity": "This command actually executes a DUMP+DEL in the source instance, and a RESTORE in the target instance. See the pages of these commands for time complexity. Also an O(N) data transfer between the two instances is performed.",
+    "arguments": [
+      {
+        "name": "host",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "port",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "key",
+        "schema": {
+          "type": "string",
+          "enum": [
+            "key",
+            "\"\""
+          ]
+        }
+      },
+      {
+        "name": "destination-db",
+        "schema": {
+          "type": "integer"
+        }
+      },
+      {
+        "name": "timeout",
+        "schema": {
+          "type": "integer"
+        }
+      },
+      {
+        "name": "copy",
+        "optional": true,
+        "schema": {
+          "type": "string",
+          "enum": [
+            "COPY"
+          ]
+        }
+      },
+      {
+        "name": "replace",
+        "optional": true,
+        "schema": {
+          "type": "string",
+          "enum": [
+            "REPLACE"
+          ]
+        }
+      },
+      {
+        "name": "password",
+        "optional": true,
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "key",
+        "optional": true,
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    ],
+    "since": "2.6.0",
+    "group": "generic",
+    "return": {
+      "type": "string"
+    }
+  },
+  "MODULE LIST": {
+    "summary": "List all modules loaded by the server",
+    "complexity": "O(N) where N is the number of loaded modules.",
+    "since": "4.0.0",
+    "group": "server",
+    "arguments": [],
+    "return": {}
+  },
+  "MODULE LOAD": {
+    "summary": "Load a module",
+    "complexity": "O(1)",
+    "arguments": [
+      {
+        "name": "path",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "arg",
+        "optional": true,
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    ],
+    "since": "4.0.0",
+    "group": "server",
+    "return": {}
+  },
+  "MODULE UNLOAD": {
+    "summary": "Unload a module",
+    "complexity": "O(1)",
+    "arguments": [
+      {
+        "name": "name",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
+    "since": "4.0.0",
+    "group": "server",
+    "return": {}
+  },
+  "MONITOR": {
+    "summary": "Listen for all requests received by the server in real time",
+    "since": "1.0.0",
+    "group": "server",
+    "arguments": [],
+    "return": {}
+  },
+  "MOVE": {
+    "summary": "Move a key to another database",
+    "complexity": "O(1)",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "db",
+        "schema": {
+          "type": "integer"
+        }
+      }
+    ],
+    "since": "1.0.0",
+    "group": "generic",
+    "return": {
+      "type": "integer"
+    }
+  },
+  "MSET": {
+    "summary": "Set multiple keys to multiple values",
+    "complexity": "O(N) where N is the number of keys to set.",
+    "arguments": [
+      {
+        "name": "key_value",
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": [
+              {
+                "title": "key",
+                "type": "string"
+              },
+              {
+                "title": "value",
+                "type": "string"
+              }
+            ]
+          }
+        }
+      }
+    ],
+    "since": "1.0.1",
+    "group": "string",
+    "return": {
+      "type": "string"
+    }
+  },
+  "MSETNX": {
+    "summary": "Set multiple keys to multiple values, only if none of the keys exist",
+    "complexity": "O(N) where N is the number of keys to set.",
+    "arguments": [
+      {
+        "name": "key_value",
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": [
+              {
+                "title": "key",
+                "type": "string"
+              },
+              {
+                "title": "value",
+                "type": "string"
+              }
+            ]
+          }
+        }
+      }
+    ],
+    "since": "1.0.1",
+    "group": "string",
+    "return": {
+      "type": "integer"
+    }
+  },
+  "MULTI": {
+    "summary": "Mark the start of a transaction block",
+    "since": "1.2.0",
+    "group": "transactions",
+    "arguments": [],
+    "return": {
+      "type": "string"
+    }
+  },
+  "OBJECT": {
+    "summary": "Inspect the internals of Redis objects",
+    "complexity": "O(1) for all the currently implemented subcommands.",
+    "since": "2.2.3",
+    "group": "generic",
+    "arguments": [
+      {
+        "name": "subcommand",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "arguments",
+        "optional": true,
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    ],
+    "return": {}
+  },
+  "PERSIST": {
+    "summary": "Remove the expiration from a key",
+    "complexity": "O(1)",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
+    "since": "2.2.0",
+    "group": "generic",
+    "return": {
+      "type": "integer"
+    }
+  },
+  "PEXPIRE": {
+    "summary": "Set a key's time to live in milliseconds",
+    "complexity": "O(1)",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "milliseconds",
+        "schema": {
+          "type": "integer"
+        }
+      }
+    ],
+    "since": "2.6.0",
+    "group": "generic",
+    "return": {
+      "type": "integer"
+    }
+  },
+  "PEXPIREAT": {
+    "summary": "Set the expiration for a key as a UNIX timestamp specified in milliseconds",
+    "complexity": "O(1)",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "milliseconds-timestamp",
+        "schema": {}
+      }
+    ],
+    "since": "2.6.0",
+    "group": "generic",
+    "return": {
+      "type": "integer"
+    }
+  },
+  "PFADD": {
+    "summary": "Adds the specified elements to the specified HyperLogLog.",
+    "complexity": "O(1) to add every element.",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "element",
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    ],
+    "since": "2.8.9",
+    "group": "hyperloglog",
+    "return": {
+      "type": "integer"
+    }
+  },
+  "PFCOUNT": {
+    "summary": "Return the approximated cardinality of the set(s) observed by the HyperLogLog at key(s).",
+    "complexity": "O(1) with a very small average constant time when called with a single key. O(N) with N being the number of keys, and much bigger constant times, when called with multiple keys.",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    ],
+    "since": "2.8.9",
+    "group": "hyperloglog",
+    "return": {
+      "type": "integer"
+    }
+  },
+  "PFMERGE": {
+    "summary": "Merge N different HyperLogLogs into a single one.",
+    "complexity": "O(N) to merge N HyperLogLogs, but with high constant times.",
+    "arguments": [
+      {
+        "name": "destkey",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "sourcekey",
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    ],
+    "since": "2.8.9",
+    "group": "hyperloglog",
+    "return": {
+      "type": "string"
+    }
+  },
+  "PING": {
+    "summary": "Ping the server",
+    "arguments": [
+      {
+        "name": "message",
+        "optional": true,
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
+    "since": "1.0.0",
+    "group": "connection",
+    "return": {
+      "type": "string"
+    }
+  },
+  "PSETEX": {
+    "summary": "Set the value and expiration in milliseconds of a key",
+    "complexity": "O(1)",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "milliseconds",
+        "schema": {
+          "type": "integer"
+        }
+      },
+      {
+        "name": "value",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
+    "since": "2.6.0",
+    "group": "string",
+    "return": {}
+  },
+  "PSUBSCRIBE": {
+    "summary": "Listen for messages published to channels matching the given patterns",
+    "complexity": "O(N) where N is the number of patterns the client is already subscribed to.",
+    "arguments": [
+      {
+        "name": "pattern",
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": [
+              {
+                "title": "pattern",
+                "type": "string"
+              }
+            ]
+          }
+        }
+      }
+    ],
+    "since": "2.0.0",
+    "group": "pubsub",
+    "return": {}
+  },
+  "PUBSUB": {
+    "summary": "Inspect the state of the Pub/Sub subsystem",
+    "complexity": "O(N) for the CHANNELS subcommand, where N is the number of active channels, and assuming constant time pattern matching (relatively short channels and patterns). O(N) for the NUMSUB subcommand, where N is the number of requested channels. O(1) for the NUMPAT subcommand.",
+    "arguments": [
+      {
+        "name": "subcommand",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "argument",
+        "optional": true,
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    ],
+    "since": "2.8.0",
+    "group": "pubsub",
+    "return": {
+      "type": "array"
+    }
+  },
+  "PTTL": {
+    "summary": "Get the time to live for a key in milliseconds",
+    "complexity": "O(1)",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
+    "since": "2.6.0",
+    "group": "generic",
+    "return": {
+      "type": "integer"
+    }
+  },
+  "PUBLISH": {
+    "summary": "Post a message to a channel",
+    "complexity": "O(N+M) where N is the number of clients subscribed to the receiving channel and M is the total number of subscribed patterns (by any client).",
+    "arguments": [
+      {
+        "name": "channel",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "message",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
+    "since": "2.0.0",
+    "group": "pubsub",
+    "return": {
+      "type": "integer"
+    }
+  },
+  "PUNSUBSCRIBE": {
+    "summary": "Stop listening for messages posted to channels matching the given patterns",
+    "complexity": "O(N+M) where N is the number of patterns the client is already subscribed and M is the number of total patterns subscribed in the system (by any client).",
+    "arguments": [
+      {
+        "name": "pattern",
+        "optional": true,
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    ],
+    "since": "2.0.0",
+    "group": "pubsub",
+    "return": {}
+  },
+  "QUIT": {
+    "summary": "Close the connection",
+    "since": "1.0.0",
+    "group": "connection",
+    "arguments": [],
+    "return": {
+      "type": "string"
+    }
+  },
+  "RANDOMKEY": {
+    "summary": "Return a random key from the keyspace",
+    "complexity": "O(1)",
+    "since": "1.0.0",
+    "group": "generic",
+    "arguments": [],
+    "return": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    }
+  },
+  "READONLY": {
+    "summary": "Enables read queries for a connection to a cluster replica node",
+    "complexity": "O(1)",
+    "since": "3.0.0",
+    "group": "cluster",
+    "arguments": [],
+    "return": {
+      "type": "string"
+    }
+  },
+  "READWRITE": {
+    "summary": "Disables read queries for a connection to a cluster replica node",
+    "complexity": "O(1)",
+    "since": "3.0.0",
+    "group": "cluster",
+    "arguments": [],
+    "return": {
+      "type": "string"
+    }
+  },
+  "RENAME": {
+    "summary": "Rename a key",
+    "complexity": "O(1)",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "newkey",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
+    "since": "1.0.0",
+    "group": "generic",
+    "return": {
+      "type": "string"
+    }
+  },
+  "RENAMENX": {
+    "summary": "Rename a key, only if the new key does not exist",
+    "complexity": "O(1)",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "newkey",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
+    "since": "1.0.0",
+    "group": "generic",
+    "return": {
+      "type": "integer"
+    }
+  },
+  "RESTORE": {
+    "summary": "Create a key using the provided serialized value, previously obtained using DUMP.",
+    "complexity": "O(1) to create the new key and additional O(N*M) to reconstruct the serialized value, where N is the number of Redis objects composing the value and M their average size. For small string values the time complexity is thus O(1)+O(1*M) where M is small, so simply O(1). However for sorted set values the complexity is O(N*M*log(N)) because inserting values into sorted sets is O(log(N)).",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "ttl",
+        "schema": {
+          "type": "integer"
+        }
+      },
+      {
+        "name": "serialized-value",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "replace",
+        "optional": true,
+        "schema": {
+          "type": "string",
+          "enum": [
+            "REPLACE"
+          ]
+        }
+      },
+      {
+        "name": "absttl",
+        "optional": true,
+        "schema": {
+          "type": "string",
+          "enum": [
+            "ABSTTL"
+          ]
+        }
+      },
+      {
+        "name": "seconds",
+        "optional": true,
+        "schema": {
+          "type": "integer"
+        }
+      },
+      {
+        "name": "frequency",
+        "optional": true,
+        "schema": {
+          "type": "integer"
+        }
+      }
+    ],
+    "since": "2.6.0",
+    "group": "generic",
+    "return": {
+      "type": "string"
+    }
+  },
+  "ROLE": {
+    "summary": "Return the role of the instance in the context of replication",
+    "since": "2.8.12",
+    "group": "server",
+    "arguments": [],
+    "return": {
+      "type": "array"
+    }
+  },
+  "RPOP": {
+    "summary": "Remove and get the last element in a list",
+    "complexity": "O(1)",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
+    "since": "1.0.0",
+    "group": "list",
+    "return": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    }
+  },
+  "RPOPLPUSH": {
+    "summary": "Remove the last element in a list, prepend it to another list and return it",
+    "complexity": "O(1)",
+    "arguments": [
+      {
+        "name": "source",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "destination",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
+    "since": "1.2.0",
+    "group": "list",
+    "return": {
+      "type": "string"
+    }
+  },
+  "RPUSH": {
+    "summary": "Append one or multiple elements to a list",
+    "complexity": "O(1) for each element added, so O(N) to add N elements when the command is called with multiple arguments.",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "element",
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    ],
+    "since": "1.0.0",
+    "group": "list",
+    "return": {
+      "type": "integer"
+    }
+  },
+  "RPUSHX": {
+    "summary": "Append an element to a list, only if the list exists",
+    "complexity": "O(1) for each element added, so O(N) to add N elements when the command is called with multiple arguments.",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "element",
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    ],
+    "since": "2.2.0",
+    "group": "list",
+    "return": {
+      "type": "integer"
+    }
+  },
+  "SADD": {
+    "summary": "Add one or more members to a set",
+    "complexity": "O(1) for each element added, so O(N) to add N elements when the command is called with multiple arguments.",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "member",
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    ],
+    "since": "1.0.0",
+    "group": "set",
+    "return": {
+      "type": "integer"
+    }
+  },
+  "SAVE": {
+    "summary": "Synchronously save the dataset to disk",
+    "since": "1.0.0",
+    "group": "server",
+    "arguments": [],
+    "return": {
+      "type": "string"
+    }
+  },
+  "SCARD": {
+    "summary": "Get the number of members in a set",
+    "complexity": "O(1)",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
+    "since": "1.0.0",
+    "group": "set",
+    "return": {
+      "type": "integer"
+    }
+  },
+  "SCRIPT DEBUG": {
+    "summary": "Set the debug mode for executed scripts.",
+    "complexity": "O(1)",
+    "arguments": [
+      {
+        "name": "mode",
+        "schema": {
+          "type": "string",
+          "enum": [
+            "YES",
+            "SYNC",
+            "NO"
+          ]
+        }
+      }
+    ],
+    "since": "3.2.0",
+    "group": "scripting",
+    "return": {}
+  },
+  "SCRIPT EXISTS": {
+    "summary": "Check existence of scripts in the script cache.",
+    "complexity": "O(N) with N being the number of scripts to check (so checking a single script is an O(1) operation).",
+    "arguments": [
+      {
+        "name": "sha1",
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    ],
+    "since": "2.6.0",
+    "group": "scripting",
+    "return": {}
+  },
+  "SCRIPT FLUSH": {
+    "summary": "Remove all the scripts from the script cache.",
+    "complexity": "O(N) with N being the number of scripts in cache",
+    "since": "2.6.0",
+    "group": "scripting",
+    "arguments": [],
+    "return": {}
+  },
+  "SCRIPT KILL": {
+    "summary": "Kill the script currently in execution.",
+    "complexity": "O(1)",
+    "since": "2.6.0",
+    "group": "scripting",
+    "arguments": [],
+    "return": {}
+  },
+  "SCRIPT LOAD": {
+    "summary": "Load the specified Lua script into the script cache.",
+    "complexity": "O(N) with N being the length in bytes of the script body.",
+    "arguments": [
+      {
+        "name": "script",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
+    "since": "2.6.0",
+    "group": "scripting",
+    "return": {}
+  },
+  "SDIFF": {
+    "summary": "Subtract multiple sets",
+    "complexity": "O(N) where N is the total number of elements in all given sets.",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    ],
+    "since": "1.0.0",
+    "group": "set",
+    "return": {
+      "type": "array"
+    }
+  },
+  "SDIFFSTORE": {
+    "summary": "Subtract multiple sets and store the resulting set in a key",
+    "complexity": "O(N) where N is the total number of elements in all given sets.",
+    "arguments": [
+      {
+        "name": "destination",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "key",
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    ],
+    "since": "1.0.0",
+    "group": "set",
+    "return": {
+      "type": "integer"
+    }
+  },
+  "SELECT": {
+    "summary": "Change the selected database for the current connection",
+    "arguments": [
+      {
+        "name": "index",
+        "schema": {
+          "type": "integer"
+        }
+      }
+    ],
+    "since": "1.0.0",
+    "group": "connection",
+    "return": {
+      "type": "string"
+    }
+  },
+  "SET": {
+    "summary": "Set the string value of a key",
+    "complexity": "O(1)",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "value",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "expiration",
+        "optional": true,
+        "schema": {
+          "type": "string",
+          "enum": [
+            "EX seconds",
+            "PX milliseconds"
+          ]
+        }
+      },
+      {
+        "name": "condition",
+        "optional": true,
+        "schema": {
+          "type": "string",
+          "enum": [
+            "NX",
+            "XX"
+          ]
+        }
+      }
+    ],
+    "since": "1.0.0",
+    "group": "string",
+    "return": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    }
+  },
+  "SETBIT": {
+    "summary": "Sets or clears the bit at offset in the string value stored at key",
+    "complexity": "O(1)",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "offset",
+        "schema": {
+          "type": "integer"
+        }
+      },
+      {
+        "name": "value",
+        "schema": {
+          "type": "integer"
+        }
+      }
+    ],
+    "since": "2.2.0",
+    "group": "string",
+    "return": {
+      "type": "integer"
+    }
+  },
+  "SETEX": {
+    "summary": "Set the value and expiration of a key",
+    "complexity": "O(1)",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "seconds",
+        "schema": {
+          "type": "integer"
+        }
+      },
+      {
+        "name": "value",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
+    "since": "2.0.0",
+    "group": "string",
+    "return": {
+      "type": "string"
+    }
+  },
+  "SETNX": {
+    "summary": "Set the value of a key, only if the key does not exist",
+    "complexity": "O(1)",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "value",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
+    "since": "1.0.0",
+    "group": "string",
+    "return": {
+      "type": "integer"
+    }
+  },
+  "SETRANGE": {
+    "summary": "Overwrite part of a string at key starting at the specified offset",
+    "complexity": "O(1), not counting the time taken to copy the new string in place. Usually, this string is very small so the amortized complexity is O(1). Otherwise, complexity is O(M) with M being the length of the value argument.",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "offset",
+        "schema": {
+          "type": "integer"
+        }
+      },
+      {
+        "name": "value",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
+    "since": "2.2.0",
+    "group": "string",
+    "return": {
+      "type": "integer"
+    }
+  },
+  "SHUTDOWN": {
+    "summary": "Synchronously save the dataset to disk and then shut down the server",
+    "arguments": [
+      {
+        "name": "save-mode",
+        "optional": true,
+        "schema": {
+          "type": "string",
+          "enum": [
+            "NOSAVE",
+            "SAVE"
+          ]
+        }
+      }
+    ],
+    "since": "1.0.0",
+    "group": "server",
+    "return": {
+      "type": "string"
+    }
+  },
+  "SINTER": {
+    "summary": "Intersect multiple sets",
+    "complexity": "O(N*M) worst case where N is the cardinality of the smallest set and M is the number of sets.",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    ],
+    "since": "1.0.0",
+    "group": "set",
+    "return": {
+      "type": "array"
+    }
+  },
+  "SINTERSTORE": {
+    "summary": "Intersect multiple sets and store the resulting set in a key",
+    "complexity": "O(N*M) worst case where N is the cardinality of the smallest set and M is the number of sets.",
+    "arguments": [
+      {
+        "name": "destination",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "key",
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    ],
+    "since": "1.0.0",
+    "group": "set",
+    "return": {
+      "type": "integer"
+    }
+  },
+  "SISMEMBER": {
+    "summary": "Determine if a given value is a member of a set",
+    "complexity": "O(1)",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "member",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
+    "since": "1.0.0",
+    "group": "set",
+    "return": {
+      "type": "integer"
+    }
+  },
+  "SLAVEOF": {
+    "summary": "Make the server a replica of another instance, or promote it as master. Deprecated starting with Redis 5. Use REPLICAOF instead.",
+    "arguments": [
+      {
+        "name": "host",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "port",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
+    "since": "1.0.0",
+    "group": "server",
+    "return": {
+      "type": "string"
+    }
+  },
+  "REPLICAOF": {
+    "summary": "Make the server a replica of another instance, or promote it as master.",
+    "arguments": [
+      {
+        "name": "host",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "port",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
+    "since": "5.0.0",
+    "group": "server",
+    "return": {
+      "type": "string"
+    }
+  },
+  "SLOWLOG": {
+    "summary": "Manages the Redis slow queries log",
+    "arguments": [
+      {
+        "name": "subcommand",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "argument",
+        "optional": true,
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
+    "since": "2.2.12",
+    "group": "server",
+    "return": {}
+  },
+  "SMEMBERS": {
+    "summary": "Get all the members in a set",
+    "complexity": "O(N) where N is the set cardinality.",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
+    "since": "1.0.0",
+    "group": "set",
+    "return": {
+      "type": "array"
+    }
+  },
+  "SMOVE": {
+    "summary": "Move a member from one set to another",
+    "complexity": "O(1)",
+    "arguments": [
+      {
+        "name": "source",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "destination",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "member",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
+    "since": "1.0.0",
+    "group": "set",
+    "return": {
+      "type": "integer"
+    }
+  },
+  "SORT": {
+    "summary": "Sort the elements in a list, set or sorted set",
+    "complexity": "O(N+M*log(M)) where N is the number of elements in the list or set to sort, and M the number of returned elements. When the elements are not sorted, complexity is currently O(N) as there is a copy step that will be avoided in next releases.",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "pattern",
+        "optional": true,
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "offset_count",
+        "optional": true,
+        "schema": {
+          "type": "array",
+          "items": [
+            {
+              "type": "string",
+              "enum": [
+                "LIMIT"
+              ]
+            },
+            {
+              "title": "offset",
+              "type": "integer"
+            },
+            {
+              "title": "count",
+              "type": "integer"
+            }
+          ]
+        }
+      },
+      {
+        "name": "pattern",
+        "optional": true,
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      {
+        "name": "order",
+        "optional": true,
+        "schema": {
+          "type": "string",
+          "enum": [
+            "ASC",
+            "DESC"
+          ]
+        }
+      },
+      {
+        "name": "sorting",
+        "optional": true,
+        "schema": {
+          "type": "string",
+          "enum": [
+            "ALPHA"
+          ]
+        }
+      },
+      {
+        "name": "destination",
+        "optional": true,
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
+    "since": "1.0.0",
+    "group": "generic",
+    "return": {
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "array"
+        }
+      ]
+    }
+  },
+  "SPOP": {
+    "summary": "Remove and return one or multiple random members from a set",
+    "complexity": "O(1)",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "count",
+        "optional": true,
+        "schema": {
+          "type": "integer"
+        }
+      }
+    ],
+    "since": "1.0.0",
+    "group": "set",
+    "return": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    }
+  },
+  "SRANDMEMBER": {
+    "summary": "Get one or multiple random members from a set",
+    "complexity": "Without the count argument O(1), otherwise O(N) where N is the absolute value of the passed count.",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "count",
+        "optional": true,
+        "schema": {
+          "type": "integer"
+        }
+      }
+    ],
+    "since": "1.0.0",
+    "group": "set",
+    "return": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "array"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    }
+  },
+  "SREM": {
+    "summary": "Remove one or more members from a set",
+    "complexity": "O(N) where N is the number of members to be removed.",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "member",
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    ],
+    "since": "1.0.0",
+    "group": "set",
+    "return": {
+      "type": "integer"
+    }
+  },
+  "STRLEN": {
+    "summary": "Get the length of the value stored in a key",
+    "complexity": "O(1)",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
+    "since": "2.2.0",
+    "group": "string",
+    "return": {
+      "type": "integer"
+    }
+  },
+  "SUBSCRIBE": {
+    "summary": "Listen for messages published to the given channels",
+    "complexity": "O(N) where N is the number of channels to subscribe to.",
+    "arguments": [
+      {
+        "name": "channel",
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": [
+              {
+                "title": "channel",
+                "type": "string"
+              }
+            ]
+          }
+        }
+      }
+    ],
+    "since": "2.0.0",
+    "group": "pubsub",
+    "return": {}
+  },
+  "SUNION": {
+    "summary": "Add multiple sets",
+    "complexity": "O(N) where N is the total number of elements in all given sets.",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    ],
+    "since": "1.0.0",
+    "group": "set",
+    "return": {
+      "type": "array"
+    }
+  },
+  "SUNIONSTORE": {
+    "summary": "Add multiple sets and store the resulting set in a key",
+    "complexity": "O(N) where N is the total number of elements in all given sets.",
+    "arguments": [
+      {
+        "name": "destination",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "key",
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    ],
+    "since": "1.0.0",
+    "group": "set",
+    "return": {
+      "type": "integer"
+    }
+  },
+  "SWAPDB": {
+    "summary": "Swaps two Redis databases",
+    "arguments": [
+      {
+        "name": "index1",
+        "schema": {
+          "type": "integer"
+        }
+      },
+      {
+        "name": "index2",
+        "schema": {
+          "type": "integer"
+        }
+      }
+    ],
+    "since": "4.0.0",
+    "group": "connection",
+    "return": {
+      "type": "string"
+    }
+  },
+  "SYNC": {
+    "summary": "Internal command used for replication",
+    "since": "1.0.0",
+    "group": "server",
+    "arguments": [],
+    "return": {}
+  },
+  "PSYNC": {
+    "summary": "Internal command used for replication",
+    "arguments": [
+      {
+        "name": "replicationid",
+        "schema": {
+          "type": "integer"
+        }
+      },
+      {
+        "name": "offset",
+        "schema": {
+          "type": "integer"
+        }
+      }
+    ],
+    "since": "2.8.0",
+    "group": "server",
+    "return": {}
+  },
+  "TIME": {
+    "summary": "Return the current server time",
+    "complexity": "O(1)",
+    "since": "2.6.0",
+    "group": "server",
+    "arguments": [],
+    "return": {
+      "type": "array"
+    }
+  },
+  "TOUCH": {
+    "summary": "Alters the last access time of a key(s). Returns the number of existing keys specified.",
+    "complexity": "O(N) where N is the number of keys that will be touched.",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    ],
+    "since": "3.2.1",
+    "group": "generic",
+    "return": {
+      "type": "integer"
+    }
+  },
+  "TTL": {
+    "summary": "Get the time to live for a key",
+    "complexity": "O(1)",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
+    "since": "1.0.0",
+    "group": "generic",
+    "return": {
+      "type": "integer"
+    }
+  },
+  "TYPE": {
+    "summary": "Determine the type stored at key",
+    "complexity": "O(1)",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
+    "since": "1.0.0",
+    "group": "generic",
+    "return": {
+      "type": "string"
+    }
+  },
+  "UNSUBSCRIBE": {
+    "summary": "Stop listening for messages posted to the given channels",
+    "complexity": "O(N) where N is the number of clients already subscribed to a channel.",
+    "arguments": [
+      {
+        "name": "channel",
+        "optional": true,
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    ],
+    "since": "2.0.0",
+    "group": "pubsub",
+    "return": {}
+  },
+  "UNLINK": {
+    "summary": "Delete a key asynchronously in another thread. Otherwise it is just as DEL, but non blocking.",
+    "complexity": "O(1) for each key removed regardless of its size. Then the command does O(N) work in a different thread in order to reclaim memory, where N is the number of allocations the deleted objects where composed of.",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    ],
+    "since": "4.0.0",
+    "group": "generic",
+    "return": {
+      "type": "integer"
+    }
+  },
+  "UNWATCH": {
+    "summary": "Forget about all watched keys",
+    "complexity": "O(1)",
+    "since": "2.2.0",
+    "group": "transactions",
+    "arguments": [],
+    "return": {
+      "type": "string"
+    }
+  },
+  "WAIT": {
+    "summary": "Wait for the synchronous replication of all the write commands sent in the context of the current connection",
+    "complexity": "O(1)",
+    "arguments": [
+      {
+        "name": "numreplicas",
+        "schema": {
+          "type": "integer"
+        }
+      },
+      {
+        "name": "timeout",
+        "schema": {
+          "type": "integer"
+        }
+      }
+    ],
+    "since": "3.0.0",
+    "group": "generic",
+    "return": {
+      "type": "integer"
+    }
+  },
+  "WATCH": {
+    "summary": "Watch the given keys to determine execution of the MULTI/EXEC block",
+    "complexity": "O(1) for every key.",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    ],
+    "since": "2.2.0",
+    "group": "transactions",
+    "return": {
+      "type": "string"
+    }
+  },
+  "ZADD": {
+    "summary": "Add one or more members to a sorted set, or update its score if it already exists",
+    "complexity": "O(log(N)) for each item added, where N is the number of elements in the sorted set.",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "condition",
+        "optional": true,
+        "schema": {
+          "type": "string",
+          "enum": [
+            "NX",
+            "XX"
+          ]
+        }
+      },
+      {
+        "name": "change",
+        "optional": true,
+        "schema": {
+          "type": "string",
+          "enum": [
+            "CH"
+          ]
+        }
+      },
+      {
+        "name": "increment",
+        "optional": true,
+        "schema": {
+          "type": "string",
+          "enum": [
+            "INCR"
+          ]
+        }
+      },
+      {
+        "name": "score_member",
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": [
+              {
+                "title": "score",
+                "type": "number"
+              },
+              {
+                "title": "member",
+                "type": "string"
+              }
+            ]
+          }
+        }
+      }
+    ],
+    "since": "1.2.0",
+    "group": "sorted_set",
+    "return": {
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    }
+  },
+  "ZCARD": {
+    "summary": "Get the number of members in a sorted set",
+    "complexity": "O(1)",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
+    "since": "1.2.0",
+    "group": "sorted_set",
+    "return": {
+      "type": "integer"
+    }
+  },
+  "ZCOUNT": {
+    "summary": "Count the members in a sorted set with scores within the given values",
+    "complexity": "O(log(N)) with N being the number of elements in the sorted set.",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "min",
+        "schema": {
+          "type": "number"
+        }
+      },
+      {
+        "name": "max",
+        "schema": {
+          "type": "number"
+        }
+      }
+    ],
+    "since": "2.0.0",
+    "group": "sorted_set",
+    "return": {
+      "type": "integer"
+    }
+  },
+  "ZINCRBY": {
+    "summary": "Increment the score of a member in a sorted set",
+    "complexity": "O(log(N)) where N is the number of elements in the sorted set.",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "increment",
+        "schema": {
+          "type": "integer"
+        }
+      },
+      {
+        "name": "member",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
+    "since": "1.2.0",
+    "group": "sorted_set",
+    "return": {
+      "type": "string"
+    }
+  },
+  "ZINTERSTORE": {
+    "summary": "Intersect multiple sorted sets and store the resulting sorted set in a new key",
+    "complexity": "O(N*K)+O(M*log(M)) worst case with N being the smallest input sorted set, K being the number of input sorted sets and M being the number of elements in the resulting sorted set.",
+    "arguments": [
+      {
+        "name": "destination",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "numkeys",
+        "schema": {
+          "type": "integer"
+        }
+      },
+      {
+        "name": "key",
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      {
+        "name": "weight",
+        "optional": true,
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "integer"
+          }
+        }
+      },
+      {
+        "name": "aggregate",
+        "optional": true,
+        "schema": {
+          "type": "string",
+          "enum": [
+            "SUM",
+            "MIN",
+            "MAX"
+          ]
+        }
+      }
+    ],
+    "since": "2.0.0",
+    "group": "sorted_set",
+    "return": {
+      "type": "integer"
+    }
+  },
+  "ZLEXCOUNT": {
+    "summary": "Count the number of members in a sorted set between a given lexicographical range",
+    "complexity": "O(log(N)) with N being the number of elements in the sorted set.",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "min",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "max",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
+    "since": "2.8.9",
+    "group": "sorted_set",
+    "return": {
+      "type": "integer"
+    }
+  },
+  "ZPOPMAX": {
+    "summary": "Remove and return members with the highest scores in a sorted set",
+    "complexity": "O(log(N)*M) with N being the number of elements in the sorted set, and M being the number of elements popped.",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "count",
+        "optional": true,
+        "schema": {
+          "type": "integer"
+        }
+      }
+    ],
+    "since": "5.0.0",
+    "group": "sorted_set",
+    "return": {
+      "type": "array"
+    }
+  },
+  "ZPOPMIN": {
+    "summary": "Remove and return members with the lowest scores in a sorted set",
+    "complexity": "O(log(N)*M) with N being the number of elements in the sorted set, and M being the number of elements popped.",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "count",
+        "optional": true,
+        "schema": {
+          "type": "integer"
+        }
+      }
+    ],
+    "since": "5.0.0",
+    "group": "sorted_set",
+    "return": {
+      "type": "array"
+    }
+  },
+  "ZRANGE": {
+    "summary": "Return a range of members in a sorted set, by index",
+    "complexity": "O(log(N)+M) with N being the number of elements in the sorted set and M the number of elements returned.",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "start",
+        "schema": {
+          "type": "integer"
+        }
+      },
+      {
+        "name": "stop",
+        "schema": {
+          "type": "integer"
+        }
+      },
+      {
+        "name": "withscores",
+        "optional": true,
+        "schema": {
+          "type": "string",
+          "enum": [
+            "WITHSCORES"
+          ]
+        }
+      }
+    ],
+    "since": "1.2.0",
+    "group": "sorted_set",
+    "return": {
+      "type": "array"
+    }
+  },
+  "ZRANGEBYLEX": {
+    "summary": "Return a range of members in a sorted set, by lexicographical range",
+    "complexity": "O(log(N)+M) with N being the number of elements in the sorted set and M the number of elements being returned. If M is constant (e.g. always asking for the first 10 elements with LIMIT), you can consider it O(log(N)).",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "min",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "max",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "offset_count",
+        "optional": true,
+        "schema": {
+          "type": "array",
+          "items": [
+            {
+              "type": "string",
+              "enum": [
+                "LIMIT"
+              ]
+            },
+            {
+              "title": "offset",
+              "type": "integer"
+            },
+            {
+              "title": "count",
+              "type": "integer"
+            }
+          ]
+        }
+      }
+    ],
+    "since": "2.8.9",
+    "group": "sorted_set",
+    "return": {
+      "type": "array"
+    }
+  },
+  "ZREVRANGEBYLEX": {
+    "summary": "Return a range of members in a sorted set, by lexicographical range, ordered from higher to lower strings.",
+    "complexity": "O(log(N)+M) with N being the number of elements in the sorted set and M the number of elements being returned. If M is constant (e.g. always asking for the first 10 elements with LIMIT), you can consider it O(log(N)).",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "max",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "min",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "offset_count",
+        "optional": true,
+        "schema": {
+          "type": "array",
+          "items": [
+            {
+              "type": "string",
+              "enum": [
+                "LIMIT"
+              ]
+            },
+            {
+              "title": "offset",
+              "type": "integer"
+            },
+            {
+              "title": "count",
+              "type": "integer"
+            }
+          ]
+        }
+      }
+    ],
+    "since": "2.8.9",
+    "group": "sorted_set",
+    "return": {
+      "type": "array"
+    }
+  },
+  "ZRANGEBYSCORE": {
+    "summary": "Return a range of members in a sorted set, by score",
+    "complexity": "O(log(N)+M) with N being the number of elements in the sorted set and M the number of elements being returned. If M is constant (e.g. always asking for the first 10 elements with LIMIT), you can consider it O(log(N)).",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "min",
+        "schema": {
+          "type": "number"
+        }
+      },
+      {
+        "name": "max",
+        "schema": {
+          "type": "number"
+        }
+      },
+      {
+        "name": "withscores",
+        "optional": true,
+        "schema": {
+          "type": "string",
+          "enum": [
+            "WITHSCORES"
+          ]
+        }
+      },
+      {
+        "name": "offset_count",
+        "optional": true,
+        "schema": {
+          "type": "array",
+          "items": [
+            {
+              "type": "string",
+              "enum": [
+                "LIMIT"
+              ]
+            },
+            {
+              "title": "offset",
+              "type": "integer"
+            },
+            {
+              "title": "count",
+              "type": "integer"
+            }
+          ]
+        }
+      }
+    ],
+    "since": "1.0.5",
+    "group": "sorted_set",
+    "return": {
+      "type": "array"
+    }
+  },
+  "ZRANK": {
+    "summary": "Determine the index of a member in a sorted set",
+    "complexity": "O(log(N))",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "member",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
+    "since": "2.0.0",
+    "group": "sorted_set",
+    "return": {
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    }
+  },
+  "ZREM": {
+    "summary": "Remove one or more members from a sorted set",
+    "complexity": "O(M*log(N)) with N being the number of elements in the sorted set and M the number of elements to be removed.",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "member",
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    ],
+    "since": "1.2.0",
+    "group": "sorted_set",
+    "return": {
+      "type": "integer"
+    }
+  },
+  "ZREMRANGEBYLEX": {
+    "summary": "Remove all members in a sorted set between the given lexicographical range",
+    "complexity": "O(log(N)+M) with N being the number of elements in the sorted set and M the number of elements removed by the operation.",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "min",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "max",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
+    "since": "2.8.9",
+    "group": "sorted_set",
+    "return": {
+      "type": "integer"
+    }
+  },
+  "ZREMRANGEBYRANK": {
+    "summary": "Remove all members in a sorted set within the given indexes",
+    "complexity": "O(log(N)+M) with N being the number of elements in the sorted set and M the number of elements removed by the operation.",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "start",
+        "schema": {
+          "type": "integer"
+        }
+      },
+      {
+        "name": "stop",
+        "schema": {
+          "type": "integer"
+        }
+      }
+    ],
+    "since": "2.0.0",
+    "group": "sorted_set",
+    "return": {
+      "type": "integer"
+    }
+  },
+  "ZREMRANGEBYSCORE": {
+    "summary": "Remove all members in a sorted set within the given scores",
+    "complexity": "O(log(N)+M) with N being the number of elements in the sorted set and M the number of elements removed by the operation.",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "min",
+        "schema": {
+          "type": "number"
+        }
+      },
+      {
+        "name": "max",
+        "schema": {
+          "type": "number"
+        }
+      }
+    ],
+    "since": "1.2.0",
+    "group": "sorted_set",
+    "return": {
+      "type": "integer"
+    }
+  },
+  "ZREVRANGE": {
+    "summary": "Return a range of members in a sorted set, by index, with scores ordered from high to low",
+    "complexity": "O(log(N)+M) with N being the number of elements in the sorted set and M the number of elements returned.",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "start",
+        "schema": {
+          "type": "integer"
+        }
+      },
+      {
+        "name": "stop",
+        "schema": {
+          "type": "integer"
+        }
+      },
+      {
+        "name": "withscores",
+        "optional": true,
+        "schema": {
+          "type": "string",
+          "enum": [
+            "WITHSCORES"
+          ]
+        }
+      }
+    ],
+    "since": "1.2.0",
+    "group": "sorted_set",
+    "return": {
+      "type": "array"
+    }
+  },
+  "ZREVRANGEBYSCORE": {
+    "summary": "Return a range of members in a sorted set, by score, with scores ordered from high to low",
+    "complexity": "O(log(N)+M) with N being the number of elements in the sorted set and M the number of elements being returned. If M is constant (e.g. always asking for the first 10 elements with LIMIT), you can consider it O(log(N)).",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "max",
+        "schema": {
+          "type": "number"
+        }
+      },
+      {
+        "name": "min",
+        "schema": {
+          "type": "number"
+        }
+      },
+      {
+        "name": "withscores",
+        "optional": true,
+        "schema": {
+          "type": "string",
+          "enum": [
+            "WITHSCORES"
+          ]
+        }
+      },
+      {
+        "name": "offset_count",
+        "optional": true,
+        "schema": {
+          "type": "array",
+          "items": [
+            {
+              "type": "string",
+              "enum": [
+                "LIMIT"
+              ]
+            },
+            {
+              "title": "offset",
+              "type": "integer"
+            },
+            {
+              "title": "count",
+              "type": "integer"
+            }
+          ]
+        }
+      }
+    ],
+    "since": "2.2.0",
+    "group": "sorted_set",
+    "return": {
+      "type": "array"
+    }
+  },
+  "ZREVRANK": {
+    "summary": "Determine the index of a member in a sorted set, with scores ordered from high to low",
+    "complexity": "O(log(N))",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "member",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
+    "since": "2.0.0",
+    "group": "sorted_set",
+    "return": {
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    }
+  },
+  "ZSCORE": {
+    "summary": "Get the score associated with the given member in a sorted set",
+    "complexity": "O(1)",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "member",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
+    "since": "1.2.0",
+    "group": "sorted_set",
+    "return": {
+      "type": "string"
+    }
+  },
+  "ZUNIONSTORE": {
+    "summary": "Add multiple sorted sets and store the resulting sorted set in a new key",
+    "complexity": "O(N)+O(M log(M)) with N being the sum of the sizes of the input sorted sets, and M being the number of elements in the resulting sorted set.",
+    "arguments": [
+      {
+        "name": "destination",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "numkeys",
+        "schema": {
+          "type": "integer"
+        }
+      },
+      {
+        "name": "key",
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      {
+        "name": "weight",
+        "optional": true,
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "integer"
+          }
+        }
+      },
+      {
+        "name": "aggregate",
+        "optional": true,
+        "schema": {
+          "type": "string",
+          "enum": [
+            "SUM",
+            "MIN",
+            "MAX"
+          ]
+        }
+      }
+    ],
+    "since": "2.0.0",
+    "group": "sorted_set",
+    "return": {
+      "type": "integer"
+    }
+  },
+  "SCAN": {
+    "summary": "Incrementally iterate the keys space",
+    "complexity": "O(1) for every call. O(N) for a complete iteration, including enough command calls for the cursor to return back to 0. N is the number of elements inside the collection.",
+    "arguments": [
+      {
+        "name": "cursor",
+        "schema": {
+          "type": "integer"
+        }
+      },
+      {
+        "name": "pattern",
+        "optional": true,
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "count",
+        "optional": true,
+        "schema": {
+          "type": "integer"
+        }
+      },
+      {
+        "name": "type",
+        "optional": true,
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
+    "since": "2.8.0",
+    "group": "generic",
+    "return": {}
+  },
+  "SSCAN": {
+    "summary": "Incrementally iterate Set elements",
+    "complexity": "O(1) for every call. O(N) for a complete iteration, including enough command calls for the cursor to return back to 0. N is the number of elements inside the collection..",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "cursor",
+        "schema": {
+          "type": "integer"
+        }
+      },
+      {
+        "name": "pattern",
+        "optional": true,
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "count",
+        "optional": true,
+        "schema": {
+          "type": "integer"
+        }
+      }
+    ],
+    "since": "2.8.0",
+    "group": "set",
+    "return": {}
+  },
+  "HSCAN": {
+    "summary": "Incrementally iterate hash fields and associated values",
+    "complexity": "O(1) for every call. O(N) for a complete iteration, including enough command calls for the cursor to return back to 0. N is the number of elements inside the collection..",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "cursor",
+        "schema": {
+          "type": "integer"
+        }
+      },
+      {
+        "name": "pattern",
+        "optional": true,
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "count",
+        "optional": true,
+        "schema": {
+          "type": "integer"
+        }
+      }
+    ],
+    "since": "2.8.0",
+    "group": "hash",
+    "return": {}
+  },
+  "ZSCAN": {
+    "summary": "Incrementally iterate sorted sets elements and associated scores",
+    "complexity": "O(1) for every call. O(N) for a complete iteration, including enough command calls for the cursor to return back to 0. N is the number of elements inside the collection..",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "cursor",
+        "schema": {
+          "type": "integer"
+        }
+      },
+      {
+        "name": "pattern",
+        "optional": true,
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "count",
+        "optional": true,
+        "schema": {
+          "type": "integer"
+        }
+      }
+    ],
+    "since": "2.8.0",
+    "group": "sorted_set",
+    "return": {}
+  },
+  "XINFO": {
+    "summary": "Get information on streams and consumer groups",
+    "complexity": "O(N) with N being the number of returned items for the subcommands CONSUMERS and GROUPS. The STREAM subcommand is O(log N) with N being the number of items in the stream.",
+    "arguments": [
+      {
+        "name": "key_groupname",
+        "optional": true,
+        "schema": {
+          "type": "array",
+          "items": [
+            {
+              "type": "string",
+              "enum": [
+                "CONSUMERS"
+              ]
+            },
+            {
+              "title": "key",
+              "type": "string"
+            },
+            {
+              "title": "groupname",
+              "type": "string"
+            }
+          ]
+        }
+      },
+      {
+        "name": "key",
+        "optional": true,
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "key",
+        "optional": true,
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "help",
+        "optional": true,
+        "schema": {
+          "type": "string",
+          "enum": [
+            "HELP"
+          ]
+        }
+      }
+    ],
+    "since": "5.0.0",
+    "group": "stream",
+    "return": {}
+  },
+  "XADD": {
+    "summary": "Appends a new entry to a stream",
+    "complexity": "O(1)",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "ID",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "field_value",
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": [
+              {
+                "title": "field",
+                "type": "string"
+              },
+              {
+                "title": "value",
+                "type": "string"
+              }
+            ]
+          }
+        }
+      }
+    ],
+    "since": "5.0.0",
+    "group": "stream",
+    "return": {
+      "type": "string"
+    }
+  },
+  "XTRIM": {
+    "summary": "Trims the stream to (approximately if '~' is passed) a certain size",
+    "complexity": "O(N), with N being the number of evicted entries. Constant times are very small however, since entries are organized in macro nodes containing multiple entries that can be released with a single deallocation.",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "strategy",
+        "schema": {
+          "type": "string",
+          "enum": [
+            "MAXLEN"
+          ]
+        }
+      },
+      {
+        "name": "approx",
+        "optional": true,
+        "schema": {
+          "type": "string",
+          "enum": [
+            "~"
+          ]
+        }
+      },
+      {
+        "name": "count",
+        "schema": {
+          "type": "integer"
+        }
+      }
+    ],
+    "since": "5.0.0",
+    "group": "stream",
+    "return": {
+      "type": "integer"
+    }
+  },
+  "XDEL": {
+    "summary": "Removes the specified entries from the stream. Returns the number of items actually deleted, that may be different from the number of IDs passed in case certain IDs do not exist.",
+    "complexity": "O(1) for each single item to delete in the stream, regardless of the stream size.",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "ID",
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    ],
+    "since": "5.0.0",
+    "group": "stream",
+    "return": {
+      "type": "integer"
+    }
+  },
+  "XRANGE": {
+    "summary": "Return a range of elements in a stream, with IDs matching the specified IDs interval",
+    "complexity": "O(N) with N being the number of elements being returned. If N is constant (e.g. always asking for the first 10 elements with COUNT), you can consider it O(1).",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "start",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "end",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "count",
+        "optional": true,
+        "schema": {
+          "type": "integer"
+        }
+      }
+    ],
+    "since": "5.0.0",
+    "group": "stream",
+    "return": {
+      "type": "array"
+    }
+  },
+  "XREVRANGE": {
+    "summary": "Return a range of elements in a stream, with IDs matching the specified IDs interval, in reverse order (from greater to smaller IDs) compared to XRANGE",
+    "complexity": "O(N) with N being the number of elements returned. If N is constant (e.g. always asking for the first 10 elements with COUNT), you can consider it O(1).",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "end",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "start",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "count",
+        "optional": true,
+        "schema": {
+          "type": "integer"
+        }
+      }
+    ],
+    "since": "5.0.0",
+    "group": "stream",
+    "return": {
+      "type": "array"
+    }
+  },
+  "XLEN": {
+    "summary": "Return the number of entires in a stream",
+    "complexity": "O(1)",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
+    "since": "5.0.0",
+    "group": "stream",
+    "return": {
+      "type": "integer"
+    }
+  },
+  "XREAD": {
+    "summary": "Return never seen elements in multiple streams, with IDs greater than the ones reported by the caller for each stream. Can block.",
+    "complexity": "For each stream mentioned: O(N) with N being the number of elements being returned, it means that XREAD-ing with a fixed COUNT is O(1). Note that when the BLOCK option is used, XADD will pay O(M) time in order to serve the M clients blocked on the stream getting new data.",
+    "arguments": [
+      {
+        "name": "count",
+        "optional": true,
+        "schema": {
+          "type": "integer"
+        }
+      },
+      {
+        "name": "milliseconds",
+        "optional": true,
+        "schema": {
+          "type": "integer"
+        }
+      },
+      {
+        "name": "streams",
+        "schema": {
+          "type": "string",
+          "enum": [
+            "STREAMS"
+          ]
+        }
+      },
+      {
+        "name": "key",
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      {
+        "name": "id",
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    ],
+    "since": "5.0.0",
+    "group": "stream",
+    "return": {
+      "type": "array"
+    }
+  },
+  "XGROUP": {
+    "summary": "Create, destroy, and manage consumer groups.",
+    "complexity": "O(1) for all the subcommands, with the exception of the DESTROY subcommand which takes an additional O(M) time in order to delete the M entries inside the consumer group pending entries list (PEL).",
+    "arguments": [
+      {
+        "name": "key_groupname_id-or-$",
+        "optional": true,
+        "schema": {
+          "type": "array",
+          "items": [
+            {
+              "type": "string",
+              "enum": [
+                "CREATE"
+              ]
+            },
+            {
+              "title": "key",
+              "type": "string"
+            },
+            {
+              "title": "groupname",
+              "type": "string"
+            },
+            {
+              "title": "id-or-$",
+              "type": "string"
+            }
+          ]
+        }
+      },
+      {
+        "name": "key_groupname_id-or-$",
+        "optional": true,
+        "schema": {
+          "type": "array",
+          "items": [
+            {
+              "type": "string",
+              "enum": [
+                "SETID"
+              ]
+            },
+            {
+              "title": "key",
+              "type": "string"
+            },
+            {
+              "title": "groupname",
+              "type": "string"
+            },
+            {
+              "title": "id-or-$",
+              "type": "string"
+            }
+          ]
+        }
+      },
+      {
+        "name": "key_groupname",
+        "optional": true,
+        "schema": {
+          "type": "array",
+          "items": [
+            {
+              "type": "string",
+              "enum": [
+                "DESTROY"
+              ]
+            },
+            {
+              "title": "key",
+              "type": "string"
+            },
+            {
+              "title": "groupname",
+              "type": "string"
+            }
+          ]
+        }
+      },
+      {
+        "name": "key_groupname_consumername",
+        "optional": true,
+        "schema": {
+          "type": "array",
+          "items": [
+            {
+              "type": "string",
+              "enum": [
+                "DELCONSUMER"
+              ]
+            },
+            {
+              "title": "key",
+              "type": "string"
+            },
+            {
+              "title": "groupname",
+              "type": "string"
+            },
+            {
+              "title": "consumername",
+              "type": "string"
+            }
+          ]
+        }
+      }
+    ],
+    "since": "5.0.0",
+    "group": "stream",
+    "return": {}
+  },
+  "XREADGROUP": {
+    "summary": "Return new entries from a stream using a consumer group, or access the history of the pending entries for a given consumer. Can block.",
+    "complexity": "For each stream mentioned: O(M) with M being the number of elements returned. If M is constant (e.g. always asking for the first 10 elements with COUNT), you can consider it O(1). On the other side when XREADGROUP blocks, XADD will pay the O(N) time in order to serve the N clients blocked on the stream getting new data.",
+    "arguments": [
+      {
+        "name": "group_consumer",
+        "schema": {
+          "type": "array",
+          "items": [
+            {
+              "type": "string",
+              "enum": [
+                "GROUP"
+              ]
+            },
+            {
+              "title": "group",
+              "type": "string"
+            },
+            {
+              "title": "consumer",
+              "type": "string"
+            }
+          ]
+        }
+      },
+      {
+        "name": "count",
+        "optional": true,
+        "schema": {
+          "type": "integer"
+        }
+      },
+      {
+        "name": "milliseconds",
+        "optional": true,
+        "schema": {
+          "type": "integer"
+        }
+      },
+      {
+        "name": "noack",
+        "optional": true,
+        "schema": {
+          "type": "string",
+          "enum": [
+            "NOACK"
+          ]
+        }
+      },
+      {
+        "name": "streams",
+        "schema": {
+          "type": "string",
+          "enum": [
+            "STREAMS"
+          ]
+        }
+      },
+      {
+        "name": "key",
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      {
+        "name": "ID",
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    ],
+    "since": "5.0.0",
+    "group": "stream",
+    "return": {}
+  },
+  "XACK": {
+    "summary": "Marks a pending message as correctly processed, effectively removing it from the pending entries list of the consumer group. Return value of the command is the number of messages successfully acknowledged, that is, the IDs we were actually able to resolve in the PEL.",
+    "complexity": "O(1) for each message ID processed.",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "group",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "ID",
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    ],
+    "since": "5.0.0",
+    "group": "stream",
+    "return": {
+      "type": "integer"
+    }
+  },
+  "XCLAIM": {
+    "summary": "Changes (or acquires) ownership of a message in a consumer group, as if the message was delivered to the specified consumer.",
+    "complexity": "O(log N) with N being the number of messages in the PEL of the consumer group.",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "group",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "consumer",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "min-idle-time",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "ID",
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      {
+        "name": "ms",
+        "optional": true,
+        "schema": {
+          "type": "integer"
+        }
+      },
+      {
+        "name": "ms-unix-time",
+        "optional": true,
+        "schema": {
+          "type": "integer"
+        }
+      },
+      {
+        "name": "count",
+        "optional": true,
+        "schema": {
+          "type": "integer"
+        }
+      },
+      {
+        "name": "force",
+        "optional": true,
+        "schema": {}
+      },
+      {
+        "name": "justid",
+        "optional": true,
+        "schema": {}
+      }
+    ],
+    "since": "5.0.0",
+    "group": "stream",
+    "return": {
+      "type": "array"
+    }
+  },
+  "XPENDING": {
+    "summary": "Return information and entries from a stream consumer group pending entries list, that are messages fetched but never acknowledged.",
+    "complexity": "O(N) with N being the number of elements returned, so asking for a small fixed number of entries per call is O(1). When the command returns just the summary it runs in O(1) time assuming the list of consumers is small, otherwise there is additional O(N) time needed to iterate every consumer.",
+    "arguments": [
+      {
+        "name": "key",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "group",
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "start_end_count",
+        "optional": true,
+        "schema": {
+          "type": "array",
+          "items": [
+            {
+              "title": "start",
+              "type": "string"
+            },
+            {
+              "title": "end",
+              "type": "string"
+            },
+            {
+              "title": "count",
+              "type": "integer"
+            }
+          ]
+        }
+      },
+      {
+        "name": "consumer",
+        "optional": true,
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
+    "since": "5.0.0",
+    "group": "stream",
+    "return": {
+      "type": "array"
+    }
+  },
+  "LATENCY DOCTOR": {
+    "summary": "Return a human readable latency analysis report.",
+    "since": "2.8.13",
+    "group": "server",
+    "arguments": [],
+    "return": {}
+  },
+  "LATENCY GRAPH": {
+    "summary": "Return a latency graph for the event.",
+    "arguments": [
+      {
+        "name": "event",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
+    "since": "2.8.13",
+    "group": "server",
+    "return": {}
+  },
+  "LATENCY HISTORY": {
+    "summary": "Return timestamp-latency samples for the event.",
+    "arguments": [
+      {
+        "name": "event",
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
+    "since": "2.8.13",
+    "group": "server",
+    "return": {}
+  },
+  "LATENCY LATEST": {
+    "summary": "Return the latest latency samples for all events.",
+    "since": "2.8.13",
+    "group": "server",
+    "arguments": [],
+    "return": {}
+  },
+  "LATENCY RESET": {
+    "summary": "Reset latency data for one or more events.",
+    "arguments": [
+      {
+        "name": "event",
+        "optional": true,
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
+    "since": "2.8.13",
+    "group": "server",
+    "return": {}
+  },
+  "LATENCY HELP": {
+    "summary": "Show helpful text about the different subcommands.",
+    "since": "2.8.13",
+    "group": "server",
+    "arguments": [],
+    "return": {}
+  }
+}

--- a/utils/print-json-schema.js
+++ b/utils/print-json-schema.js
@@ -1,0 +1,124 @@
+const cmnds = require('../commands')
+
+/** @type {(arg, command: string) => import('json-schema').JSONSchema7} */
+const argToSchema = (arg, command) => {
+  if (arg.multiple || arg.variadic) {
+    return {
+      type: 'array',
+      items: argToSchema({...arg, multiple: false, variadic: false}, command)
+    }
+  }
+  const stringTypes = new Set(['key', 'string', 'pattern', 'type'])
+  if (stringTypes.has(arg.type)) {
+    return {
+      type: 'string',
+    }
+  }
+  if (arg.type === 'integer') {
+    return {
+      type: 'integer',
+    }
+  }
+  if (arg.type === 'double') {
+    return {
+      type: 'number',
+    }
+  }
+  if (arg.type === 'enum') {
+    return {
+      type: 'string',
+      enum: arg.enum,
+    }
+  }
+  if (typeof arg.command === 'string') {
+    if (arg.multiple) {
+      throw Error(`don't know how to handle this`)
+    }
+    const types = Array.isArray(arg.type) ? arg.type : [arg.type]
+    const names = Array.isArray(arg.name) ? arg.name : [arg.name]
+    return {
+      type: 'array',
+      items: [
+        {type: 'string', enum: [arg.command]},
+        ...types.map((type, i) => ({
+          title: names[i],
+          ...argToSchema({type, name: names[i]}),
+        }))
+      ]
+    }
+  }
+  if (Array.isArray(arg.type)) {
+    return {
+      type: 'array',
+      items: arg.type.map((type, i) => ({
+        title: arg.name[i],
+        ...argToSchema({type, name: arg.name[i]}),
+      })),
+    }
+  }
+  return {}
+}
+
+/** @type {(arg, command: string) => import('json-schema').JSONSchema7} */
+const argToReturn = (command) => {
+  const docFile = `commands/${command.toLowerCase()}.md`
+  const fs = require('fs')
+  if (!fs.existsSync(docFile)) {
+    return {}
+  }
+  const doc = fs.readFileSync(docFile).toString()
+  if (!doc.includes('@return')) {
+    return {}
+  }
+  const returnDoc = doc.split('@return')[1].split('@example')[0]
+  const mapping = {
+    "@integer-reply": "integer",
+    "@simple-string-reply: `OK`": `string`,
+    "@string-reply": "string",
+    "@bulk-string-reply: `nil`": "null",
+    "@bulk-string-reply": "string",
+    "@simple-string-reply": "string",
+    "@array-reply": "array",
+    "@nil-reply": "null",
+    "@null-reply": "null",
+    "NULL": "null",
+    "`nil`": "null",
+  };
+  /** @type {string[]} */
+  const typeMatches = Object.keys(mapping).reduce(
+    (obj, key) => ({
+      returnDoc: obj.returnDoc.split(key).join(""),
+      matches: obj.returnDoc.includes(key) ? obj.matches.concat([mapping[key]]) : obj.matches
+    }),
+    {returnDoc, matches: []}
+  ).matches;
+  if (typeMatches.length === 0) {
+    return {}
+  }
+  if (typeMatches.length === 1) {
+    return {type: typeMatches[0]}
+  }
+  return {
+    anyOf: typeMatches.map(type => ({type}))
+  }
+}
+const jsonified = Object.keys(cmnds).reduce(
+  (dict, key, i, r) => (() => {
+    const command = cmnds[key]
+    return {
+      ...dict,
+      [key]: {
+        ...command,
+        arguments: (command.arguments || []).map(arg => ({
+          name: Array.isArray(arg.name) ? arg.name.join('_') : arg.name,
+          optional: command && arg.optional,
+          schema: argToSchema(arg, command),
+        })),
+        return: argToReturn(key),
+      },
+    }
+  })(),
+  {}
+)
+
+console.log(JSON.stringify(jsonified, null, 2))


### PR DESCRIPTION
@itamarhaber this is an idea following the discussion over the DSL in https://github.com/antirez/redis-doc/pull/1231

This PR consists of a small js script which parses `commands.json` to produce a json file in a slightly different format. Each command has the same root-level properties, except for `arguments`, which is now in the format:

```typescript
{
  name: string;
  optional: boolean;
  schema: JSONSchema7;
}
```

This allows redis to avoid re-inventing the wheel for any of the undifferentiated schema-description parts of the documentation, instead relying on [json-schema](https://json-schema.org/), which is well established, widely used, unambiguous, flexible enough to cover edge-cases, and a good balance of human- and machine-readable.

It's worth taking a look at the [generated json-schema file](https://github.com/mmkal/redis-doc/blob/1b9ed2343df263405ec69d53ffbeec0e8d355d7d/commands.json-schema.json), since it's large so github suppresses the diff. 

Note:

Each argument is represented by JSON-schema, but conceptually the schemas are "flattened" when passed as CLI arguments. For example, [`DEL`](https://github.com/mmkal/redis-doc/blob/1b9ed2343df263405ec69d53ffbeec0e8d355d7d/commands.json-schema.json#L1086-L1105). This has one argument, `key` which is of type `array`, meaning it would be valid for inputs like `['foo', 'bar']`, corresponding to `redis del foo bar`. So to go from arguments valid per the schema to a CLI call, clients would have to do something like `redis ${command} ${flatten(arguments).join(' ')}`.

I also wrote a simple function that parses the `.md` documentation for each command to extract the return type and convert to json-schema, so that type can be kept alongside the arguments. Going forward, this json file could become the source of truth for return types, so that this repo could document not just return types like `array-reply`, but specify the type of the items in the array too (e.g. `{ "type": "array", "items": { "type": "string" } }`).

This will make client generation much easier, because existing json-schema tooling can be used rather than each client library having to write a custom parser which reverse-engineers the custom DSL currently in `command.json`. (The [library I maintain](https://github.com/mmkal/handy-redis) does exactly this, and has a lot of hacks and pieces of difficult-to-maintain code. I have held off adding it to client.json so far because of this).

My thought was that if this accepted, the generated `commands.json-schema.json` acts as a starting point, and would eventually take the place of `commands.json`, and be manually edited, as the source of truth, going forwards. The js file shouldn't need to hang around, it's just for generating the "starter" json-schema file. This will allow taking advantage of json-schema's API to go further with type specificity. For example, the problem highlighted in https://github.com/antirez/redis-doc/pull/1231 would go away, because `SET` could become (using yaml for conciseness):

```yaml
summary: Set the string value of a key
complexity: O(1)
arguments:
- name: key
  schema:
    type: string
- name: value
  schema:
    type: string
- name: expiration
  optional: true
  schema:
    type: array
    items:
    - type: enum
      enum: [EX, PX]
    - type: integer
- name: condition
  optional: true
  schema:
    type: string
    enum:
    - NX
    - XX
since: 1.0.0
group: string
return:
  anyOf:
  - type: string
  - type: 'null'
```