### PR TITLE
Listing other not logged commands by MONITOR

### DIFF
--- a/commands/monitor.md
+++ b/commands/monitor.md
@@ -45,6 +45,13 @@ Manually issue the `QUIT` command to stop a `MONITOR` stream running via
 For security concerns, certain special administration commands like `CONFIG`
 are not logged into the `MONITOR` output.
 
+Other not logged commands: 
+
+ * `AUTH` (start from Redis 6.0)
+ * `EXEC`
+ * `HELLO`
+ * `QUIT`
+
 ## Cost of running `MONITOR`
 
 Because `MONITOR` streams back **all** commands, its use comes at a cost.

--- a/commands/monitor.md
+++ b/commands/monitor.md
@@ -42,17 +42,17 @@ Manually issue the `QUIT` command to stop a `MONITOR` stream running via
 
 ## Commands not logged by MONITOR
 
-For security concerns, certain special administration commands like `CONFIG`
-are not logged into the `MONITOR` output.
+Because of security concerns, all administrative commands are not logged
+by `MONITOR`'s output.
 
-Other not logged commands: 
+Furthermore, the following commands are also not logged:
 
- * `AUTH` (start from Redis 6.0)
+ * `AUTH`
  * `EXEC`
  * `HELLO`
  * `QUIT`
 
-## Cost of running `MONITOR`
+## Cost of running MONITOR
 
 Because `MONITOR` streams back **all** commands, its use comes at a cost.
 The following (totally unscientific) benchmark numbers illustrate what the cost
@@ -88,3 +88,7 @@ Running more `MONITOR` clients will reduce throughput even more.
 
 **Non standard return value**, just dumps the received commands in an infinite
 flow.
+
+@history
+
+* `>=6.0`: `AUTH`, `EXEC`, `HELLO` and `QUIT` excluded from output.


### PR DESCRIPTION
Other than admin commands ([1][2]), there are several not logged commands. List them on the same section could be helpful I think.

[1] https://github.com/antirez/redis/commit/d6410ed19a4930895f2591eed224d5ec5449393a
[2] https://github.com/antirez/redis-doc/commit/80129ef3a0fc0e48aeda73f9c9b790cf7bdb2636