### PR TITLE
Fix typo in ACL GENPASS command docs

### DIFF
--- a/commands/acl-genpass.md
+++ b/commands/acl-genpass.md
@@ -10,7 +10,7 @@ By default (if /dev/urandom is available) the password is strong and
 can be used for other uses in the context of a Redis application, for
 instance in order to create unique session identifiers or other kind of
 unguessable and not colliding IDs. The password generation is also very cheap
-because we don't really ask /de/urandom for bits at every execution. At
+because we don't really ask /dev/urandom for bits at every execution. At
 startup Redis creates a seed using /dev/urandom, then it will use SHA256
 in counter mode, with HMAC-SHA256(seed,counter) as primitive, in order to
 create more random bytes as needed. This means that the application developer


### PR DESCRIPTION
/de/urandom -> /dev/urandom