### PR TITLE
Add dbx module in list

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -317,5 +317,15 @@
       "linfangrong"
     ],
     "stars": 0
+  },
+  {
+    "name": "dbx",
+    "license": "MIT",
+    "repository": "https://github.com/cscan/dbx",
+    "description": "Redis module for maintaining hash by simple SQL",
+    "authors": [
+      "cscan"
+    ],
+    "stars": 0
   }
 ]


### PR DESCRIPTION
A simple light-weight module to maintain the hash table by common sql users. No any garbage dataset is used. This module could make redis more easy to maintain and learn.