### PR TITLE
Correct BITFIELD syntax.

### DIFF
--- a/commands/bitfield.md
+++ b/commands/bitfield.md
@@ -43,7 +43,7 @@ bit offset inside the string.
 However if the offset is prefixed with a `#` character, the specified offset
 is multiplied by the integer type width, so for example:
 
-    BITFIELD mystring SET i8 #0 100 i8 #1 200
+    BITFIELD mystring SET i8 #0 100 SET i8 #1 200
 
 Will set the first i8 integer at offset 0 and the second at offset 8.
 This way you don't have to do the math yourself inside your client if what


### PR DESCRIPTION
This snippet is missing (I think) a `SET` argument.

    127.0.0.1:6379> BITFIELD mystring SET i8 #0 100 i8 #1 200
    (error) ERR syntax error
    127.0.0.1:6379> BITFIELD mystring SET i8 #0 100 SET i8 #1 200
    1) (integer) 0
    2) (integer) 0
    127.0.0.1:6379> get mystring
    "d\xc8"