### PR TITLE
fix semver version in commands.json

### DIFF
--- a/commands.json
+++ b/commands.json
@@ -482,7 +482,7 @@
         ]
       }
     ],
-    "since": "3.2",
+    "since": "3.2.0",
     "group": "connection"
   },
   "CLIENT SETNAME": {


### PR DESCRIPTION
I want to use commands.json for some type definitions but 3.2 is not a valid semver version. 