### PR TITLE
Add other reply in the bgsave.md

### DIFF
--- a/commands/bgsave.md
+++ b/commands/bgsave.md
@@ -21,13 +21,7 @@ Please refer to the [persistence documentation][tp] for detailed information.
 
 @return
 
-@simple-string-reply: `Background saving started` if `BGSAVE` started correctly.
-
-@simple-string-reply: `Background saving scheduled` if use `SCHEDULE` option thought
-an AOF rewrite is in progress.
-
-@error-reply: `Background save already in progress` if there is already a background
-save running whatever use `SCHEDULE` option or not.
+@simple-string-reply: `Background saving started` if `BGSAVE` started correctly or `Background saving scheduled` when used with the `SCHEDULE` subcommand. 
 
 @history
 

--- a/commands/bgsave.md
+++ b/commands/bgsave.md
@@ -23,6 +23,12 @@ Please refer to the [persistence documentation][tp] for detailed information.
 
 @simple-string-reply: `Background saving started` if `BGSAVE` started correctly.
 
+@simple-string-reply: `Background saving scheduled` if use `SCHEDULE` option thought
+an AOF rewrite is in progress.
+
+@error-reply: `Background save already in progress` if there is already a background
+save running whatever use `SCHEDULE` option or not.
+
 @history
 
 * `>= 3.2.2`: Added the `SCHEDULE` option.


### PR DESCRIPTION
Add other reply in the doc.

reference from https://github.com/antirez/redis/blob/fe9acb3469508b1af721d15320b89e2bb2abdd0c/src/rdb.c#L2559

```c
/* BGSAVE [SCHEDULE] */
void bgsaveCommand(client *c) {
    int schedule = 0;

    /* The SCHEDULE option changes the behavior of BGSAVE when an AOF rewrite
     * is in progress. Instead of returning an error a BGSAVE gets scheduled. */
    if (c->argc > 1) {
        if (c->argc == 2 && !strcasecmp(c->argv[1]->ptr,"schedule")) {
            schedule = 1;
        } else {
            addReply(c,shared.syntaxerr);
            return;
        }
    }

    rdbSaveInfo rsi, *rsiptr;
    rsiptr = rdbPopulateSaveInfo(&rsi);

    if (server.rdb_child_pid != -1) {
        addReplyError(c,"Background save already in progress");
    } else if (hasActiveChildProcess()) {
        if (schedule) {
            server.rdb_bgsave_scheduled = 1;
            addReplyStatus(c,"Background saving scheduled");
        } else {
            addReplyError(c,
            "Another child process is active (AOF?): can't BGSAVE right now. "
            "Use BGSAVE SCHEDULE in order to schedule a BGSAVE whenever "
            "possible.");
        }
    } else if (rdbSaveBackground(server.rdb_filename,rsiptr) == C_OK) {
        addReplyStatus(c,"Background saving started");
    } else {
        addReply(c,shared.err);
    }
}
```