### PR TITLE
fix: remove faulty cli annotation in data-types.md

### DIFF
--- a/topics/data-types.md
+++ b/topics/data-types.md
@@ -89,7 +89,6 @@ Hashes
 
 Redis Hashes are maps between string fields and string values, so they are the perfect data type to represent objects (e.g. A User with a number of fields like name, surname, age, and so forth):
 
-    @cli
     HMSET user:1000 username antirez password P1pp0 age 34
     HGETALL user:1000
     HSET user:1000 password 12345


### PR DESCRIPTION
Fixes the rendering of this snippet on the website:

<img width="630" alt="image" src="https://user-images.githubusercontent.com/57224/83974049-a27aec80-a8ea-11ea-94db-70f9e8315798.png">
