### PR TITLE
bugfix: add USER option for CLIENT KILL command.

### DIFF
--- a/commands.json
+++ b/commands.json
@@ -433,6 +433,12 @@
         "optional": true
       },
       {
+        "command": "USER",
+        "name": "username",
+        "type": "string",
+        "optional": true
+      },
+      {
         "command": "ADDR",
         "name": "ip:port",
         "type": "string",


### PR DESCRIPTION
Redis 6 support `CLIENT KILL USER username`,  [client-kill.md](https://github.com/antirez/redis-doc/blob/8eb6eb6d632af46c0a05ac01a4af5411252e96ae/commands/client-kill.md#L18) was updated but not with commands.json