### PR TITLE
update tracking doc to make it consistant with implementation

### DIFF
--- a/topics/client-side-caching.md
+++ b/topics/client-side-caching.md
@@ -226,15 +226,8 @@ In order to do so, tracking must be enabled using the OPTIN option:
 
 In this mode, by default keys mentioned in read queries *are not supposed to be cached*, instead when a client wants to cache something, it must send a special command immediately before the actual command to retrieve the data:
 
-    CACHING
+    CLIENT CACHING YES
     +OK
-    GET foo
-    "bar"
-
-To make the protocol more efficient, the `CACHING` command can be sent with the
-`NOREPLY` option: in this case it will be totally silent:
-
-    CACHING NOREPLY
     GET foo
     "bar"
 


### PR DESCRIPTION
This PR fix two things:
1. use the correct command for enabling client tracking for next keys in opt in mode
2. since noreply was not supported in current version of Redis(not sure whether we need to support it later or not), but in my point of view we should not include this in this documentation in order to avoid confusion for users.. 