### PR TITLE
Add Ballerina to the list of languages

### DIFF
--- a/languages.json
+++ b/languages.json
@@ -1,6 +1,7 @@
 {
     "ActionScript": "actionscript",
     "ActiveX/COM+": "activex-com",
+    "Ballerina": "ballerina",
     "Bash": "bash",
     "Boomi": "boomi",
     "C": "c",


### PR DESCRIPTION
The client added in #2682 isn't visible. It seems the language must exist in the langauges.json file.