### PR TITLE
Improve language around keyspace notifications

### DIFF
--- a/docs/manual/keyspace-notifications.md
+++ b/docs/manual/keyspace-notifications.md
@@ -51,8 +51,8 @@ just the subset of events we are interested in.
 
 ### Configuration
 
-By default keyspace event notifications are disabled because while not
-very sensible the feature uses some CPU power. Notifications are enabled
+By default, keyspace event notifications are disabled because, while not
+very perceptible, the feature uses some CPU power. Notifications are enabled
 using the `notify-keyspace-events` of redis.conf or via the **CONFIG SET**.
 
 Setting the parameter to the empty string disables notifications.


### PR DESCRIPTION
Effectively, replace usage of the word `sensible` (which means "practical" and not "able to be sensed") with `perceptible`. This threw me for a loop on first read. 😅 